### PR TITLE
fix: point ESM types condition to dist/index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-4",
+  "version": "2.1.0-5",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -15,7 +15,7 @@
       },
       "source": "./src/index.ts",
       "import": {
-        "types": "./dist/index.d.mts",
+        "types": "./dist/index.d.ts",
         "default": "./dist/index.mjs"
       },
       "require": {


### PR DESCRIPTION
The exports.import.types field referenced dist/index.d.mts which is never generated by the build (tsc produces .d.ts, not .d.mts). This caused TypeScript with moduleResolution:bundler to fail resolving any types from the package, producing ~260 TS2305 errors in quorum-desktop.