### PR TITLE
feat: add dropdownClassName prop to Select for portal dropdown styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-5",
+  "version": "2.1.0-6",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/primitives/Select/Select.web.tsx
+++ b/src/primitives/Select/Select.web.tsx
@@ -20,6 +20,7 @@ const Select: React.FC<WebSelectProps> = ({
   fullWidth = false,
   width,
   dropdownPlacement = 'auto',
+  dropdownClassName,
   name,
   id,
   autoFocus = false,
@@ -373,7 +374,7 @@ const Select: React.FC<WebSelectProps> = ({
           <Portal>
             <div
               ref={dropdownRef}
-              className="quorum-select__dropdown quorum-select__dropdown--fixed"
+              className={`quorum-select__dropdown quorum-select__dropdown--fixed${dropdownClassName ? ` ${dropdownClassName}` : ''}`}
               role="listbox"
               style={dropdownStyle}
               aria-label={placeholder}

--- a/src/primitives/Select/types.ts
+++ b/src/primitives/Select/types.ts
@@ -60,6 +60,7 @@ export interface WebSelectProps extends BaseSelectProps {
   id?: string;
   autoFocus?: boolean;
   dropdownPlacement?: 'top' | 'bottom' | 'auto'; // Dropdown positioning
+  dropdownClassName?: string; // Extra CSS class(es) for the portal dropdown
 }
 
 export interface NativeSelectProps extends BaseSelectProps {


### PR DESCRIPTION
Allows consumers to pass custom CSS classes to the portal-rendered dropdown element, enabling context-specific styling (e.g. panel dropdowns). Bump version to 2.1.0-6.