### PR TITLE
fix: add user_address and user_icon alias fields to SpaceMember type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-6",
+  "version": "2.1.0-7",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -85,4 +85,8 @@ export type SpaceMember = UserProfile & {
   isKicked?: boolean;
   joinedAt?: number;
   spaceTag?: BroadcastSpaceTag;
+  /** Alias for `address` - matches SDK wire format (channel.UserProfile) and desktop IndexedDB keyPath */
+  user_address?: string;
+  /** Alias for `profile_image` - matches SDK wire format (channel.UserProfile) */
+  user_icon?: string;
 };


### PR DESCRIPTION
Desktop IndexedDB stores members with SDK field names (user_address, user_icon) while the shared SpaceMember type uses (address, profile_image). This adds optional alias fields so both conventions are valid, eliminating the need for unsafe type casts in the desktop adapter layer.

Bumps version to 2.1.0-7.