### PR TITLE
feat: user notes support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-10",
+  "version": "2.1.0-11",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/primitives/Icon/iconMapping.ts
+++ b/src/primitives/Icon/iconMapping.ts
@@ -128,6 +128,7 @@ export const iconComponentMap: Record<IconName, string> = {
   'calendar-alt': 'IconCalendar',
   history: 'IconHistory',
   memo: 'IconNote',
+  notes: 'IconNotes',
 
   // Devices & Hardware
   desktop: 'IconDeviceDesktop',

--- a/src/primitives/Icon/types.ts
+++ b/src/primitives/Icon/types.ts
@@ -119,6 +119,7 @@ export type IconName =
   | 'calendar-alt'
   | 'history'
   | 'memo'
+  | 'notes'
 
   // Devices & Hardware
   | 'desktop'

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -58,6 +58,8 @@ export type UserConfig = {
   };
   bookmarks?: Bookmark[];
   deletedBookmarkIds?: string[];
+  userNotes?: { targetAddress: string; note: string; updatedAt: number }[];
+  deletedUserNoteAddresses?: string[];
   bio?: string;
   mutedChannels?: {
     [spaceId: string]: string[];


### PR DESCRIPTION
## Summary

- Adds `notes` icon (`IconNotes`) to the icon mapping
- Adds `userNotes?: { targetAddress: string; note: string; updatedAt: number }[]` to `UserConfig` for cross-device sync support
- Adds `deletedUserNoteAddresses?: string[]` to `UserConfig` for deletion tombstones (same pattern as `deletedBookmarkIds`)
- Bumps version to `2.1.0-11`

## Context

User notes is a private per-user annotation feature (similar to Discord's Note field). v1 stores notes locally in IndexedDB in `quorum-desktop`. These `UserConfig` fields enable sync across devices in a follow-up PR once `allowSync` is wired up in `ConfigService`.

## Test plan

- [ ] TypeScript compiles cleanly in `quorum-shared`
- [ ] `quorum-desktop` consuming the updated types compiles without errors
- [ ] No runtime changes — type-only additions