### PR TITLE
feat(receipts): add ReceiptService and complete receipt types

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ src/
 ├── transport/    # HTTP and WebSocket clients
 ├── sync/         # Hash-based delta synchronization
 ├── typing/       # Ephemeral typing-indicator service
+├── receipts/     # Delivery + read receipt service
 └── storage/      # Storage adapter interface
 ```
 
@@ -38,6 +39,9 @@ Hash-based delta synchronization protocol. Computes content hashes, builds manif
 
 ### Typing
 Platform-agnostic typing-indicator service. Owns the wire protocol (`TypingMessage`), per-scope throttle (5s) and TTL (8s), privacy gating, and subscribe/notify routing. Consuming apps supply send callbacks (`sendDM`, `sendSpace`) and the privacy gate; the rendering layer stays per-app.
+
+### Receipts
+Platform-agnostic delivery + read receipt service. Owns the wire protocol (`DeliveryAckMessage`, `ReadAckMessage`), per-address delivery ack buffering with a 10s timer flush, per-address read high-water mark with a 5s debounce flush, and the piggyback / standalone coordination. Consuming apps supply callbacks for encrypted send (`onFlush`, `onReadFlush`) and cache updates (`onAckProcessed`, `onReadAckProcessed`); the intercept layer, action queue handlers, and UI components stay per-app. Browser-only background-flush listener (`visibilitychange` + `beforeunload`) is guarded with `typeof document/window` checks so the same code runs unchanged on React Native.
 
 ### Transport
 HTTP and WebSocket client abstractions for both browser and React Native environments.
@@ -178,4 +182,4 @@ The build produces:
 
 ---
 
-_Updated: 2026-05-20_
+_Updated: 2026-05-20 (twice)_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-12",
+  "version": "2.1.0-13",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -37,11 +37,11 @@
     "@noble/hashes": "^1.3.0",
     "dayjs": "^1.11.19",
     "multiformats": "^13.3.1",
-    "unified": "^11.0.0",
-    "remark-parse": "^11.0.0",
     "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
-    "strip-markdown": "^6.0.0"
+    "strip-markdown": "^6.0.0",
+    "unified": "^11.0.0"
   },
   "peerDependencies": {
     "@react-native-async-storage/async-storage": ">=1.19.0",
@@ -108,6 +108,7 @@
     "expo-document-picker": "^55.0.8",
     "expo-haptics": "^55.0.8",
     "expo-image-picker": "^55.0.12",
+    "jsdom": "^29.1.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-dropzone": "^14.4.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,5 +34,8 @@ export * from './sync';
 // Typing (ephemeral typing-indicator service)
 export * from './typing';
 
+// Receipts (delivery + read receipt service)
+export * from './receipts';
+
 // Primitives (UI components)
 export * from './primitives';

--- a/src/receipts/index.ts
+++ b/src/receipts/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Receipts Module
+ *
+ * Delivery + read receipt service. Platform-agnostic — caller supplies
+ * encrypted send and cache-update callbacks via the constructor.
+ */
+
+export { ReceiptService } from './service';
+export type { ReceiptServiceOptions } from './service';

--- a/src/receipts/service.test.ts
+++ b/src/receipts/service.test.ts
@@ -1,0 +1,367 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ReceiptService } from './service';
+
+describe('ReceiptService', () => {
+  let service: ReceiptService;
+  let mockFlushCallback: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockFlushCallback = vi.fn();
+    service = new ReceiptService({ onFlush: mockFlushCallback as never });
+  });
+
+  afterEach(() => {
+    service.destroy();
+    vi.useRealTimers();
+  });
+
+  describe('onMessageReceived', () => {
+    it('buffers messageId for the given address', () => {
+      service.onMessageReceived('alice', 'msg-1');
+      const ids = service.flushForPiggyback('alice');
+      expect(ids).toEqual(['msg-1']);
+    });
+
+    it('buffers multiple messageIds for same address', () => {
+      service.onMessageReceived('alice', 'msg-1');
+      service.onMessageReceived('alice', 'msg-2');
+      const ids = service.flushForPiggyback('alice');
+      expect(ids).toEqual(['msg-1', 'msg-2']);
+    });
+
+    it('deduplicates messageIds', () => {
+      service.onMessageReceived('alice', 'msg-1');
+      service.onMessageReceived('alice', 'msg-1');
+      const ids = service.flushForPiggyback('alice');
+      expect(ids).toEqual(['msg-1']);
+    });
+
+    it('buffers separately per address', () => {
+      service.onMessageReceived('alice', 'msg-1');
+      service.onMessageReceived('bob', 'msg-2');
+      expect(service.flushForPiggyback('alice')).toEqual(['msg-1']);
+      expect(service.flushForPiggyback('bob')).toEqual(['msg-2']);
+    });
+  });
+
+  describe('flushForPiggyback', () => {
+    it('clears buffer and cancels timer for that address', () => {
+      service.onMessageReceived('alice', 'msg-1');
+      service.flushForPiggyback('alice');
+      // Buffer should be empty now
+      expect(service.flushForPiggyback('alice')).toEqual([]);
+      // Timer should not fire
+      vi.advanceTimersByTime(15000);
+      expect(mockFlushCallback).not.toHaveBeenCalled();
+    });
+
+    it('returns empty array if no pending acks', () => {
+      expect(service.flushForPiggyback('alice')).toEqual([]);
+    });
+  });
+
+  describe('timer-based flush', () => {
+    it('calls onFlush after 10 seconds if no piggyback', () => {
+      service.onMessageReceived('alice', 'msg-1');
+      vi.advanceTimersByTime(10000);
+      expect(mockFlushCallback).toHaveBeenCalledWith('alice', ['msg-1']);
+    });
+
+    it('does not call onFlush before 10 seconds', () => {
+      service.onMessageReceived('alice', 'msg-1');
+      vi.advanceTimersByTime(9999);
+      expect(mockFlushCallback).not.toHaveBeenCalled();
+    });
+
+    it('resets timer when new message arrives for same address', () => {
+      service.onMessageReceived('alice', 'msg-1');
+      vi.advanceTimersByTime(8000);
+      service.onMessageReceived('alice', 'msg-2');
+      vi.advanceTimersByTime(8000);
+      // Should not have fired at original 10s mark
+      expect(mockFlushCallback).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(2000);
+      // Should fire at 10s after msg-2
+      expect(mockFlushCallback).toHaveBeenCalledWith('alice', ['msg-1', 'msg-2']);
+    });
+  });
+
+  describe('flushAll', () => {
+    it('flushes all addresses and calls onFlush for each', () => {
+      service.onMessageReceived('alice', 'msg-1');
+      service.onMessageReceived('bob', 'msg-2');
+      service.flushAll();
+      expect(mockFlushCallback).toHaveBeenCalledWith('alice', ['msg-1']);
+      expect(mockFlushCallback).toHaveBeenCalledWith('bob', ['msg-2']);
+    });
+
+    it('clears all buffers and timers', () => {
+      service.onMessageReceived('alice', 'msg-1');
+      service.flushAll();
+      vi.advanceTimersByTime(15000);
+      // Should only have been called once (from flushAll, not timer)
+      expect(mockFlushCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onAckReceived', () => {
+    it('calls onAckProcessed for each messageId', () => {
+      const mockAckProcessed = vi.fn();
+      service = new ReceiptService({
+        onFlush: mockFlushCallback as never,
+        onAckProcessed: mockAckProcessed as never,
+      });
+      service.onAckReceived(['msg-1', 'msg-2']);
+      expect(mockAckProcessed).toHaveBeenCalledWith(['msg-1', 'msg-2']);
+    });
+
+    it('does not call onAckProcessed when empty array', () => {
+      const mockAckProcessed = vi.fn();
+      service = new ReceiptService({
+        onFlush: mockFlushCallback as never,
+        onAckProcessed: mockAckProcessed as never,
+      });
+      service.onAckReceived([]);
+      expect(mockAckProcessed).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onReadAckReceived', () => {
+    it('calls onReadAckProcessed with correct arguments', () => {
+      const mockReadAckProcessed = vi.fn();
+      service = new ReceiptService({
+        onFlush: mockFlushCallback as never,
+        onReadAckProcessed: mockReadAckProcessed as never,
+      });
+      service.onReadAckReceived('msg-5', 5000, 'alice');
+      expect(mockReadAckProcessed).toHaveBeenCalledWith('msg-5', 5000, 'alice');
+    });
+
+  });
+});
+
+describe('Read receipt buffering', () => {
+  let service: ReceiptService;
+  let mockFlushCallback: ReturnType<typeof vi.fn>;
+  let mockReadFlushCallback: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockFlushCallback = vi.fn();
+    mockReadFlushCallback = vi.fn();
+    service = new ReceiptService({
+      onFlush: mockFlushCallback as never,
+      onReadFlush: mockReadFlushCallback as never,
+    });
+  });
+
+  afterEach(() => {
+    service.destroy();
+    vi.useRealTimers();
+  });
+
+  describe('onMessageRead', () => {
+    it('stores high-water mark for an address', () => {
+      service.onMessageRead('alice', 'msg-1', 1000);
+      const result = service.flushReadForPiggyback('alice');
+      expect(result).toEqual({ messageId: 'msg-1', timestamp: 1000 });
+    });
+
+    it('updates high-water mark when higher timestamp arrives', () => {
+      service.onMessageRead('alice', 'msg-1', 1000);
+      service.onMessageRead('alice', 'msg-2', 2000);
+      const result = service.flushReadForPiggyback('alice');
+      expect(result).toEqual({ messageId: 'msg-2', timestamp: 2000 });
+    });
+
+    it('ignores lower timestamp than current high-water mark', () => {
+      service.onMessageRead('alice', 'msg-2', 2000);
+      service.onMessageRead('alice', 'msg-1', 1000);
+      const result = service.flushReadForPiggyback('alice');
+      expect(result).toEqual({ messageId: 'msg-2', timestamp: 2000 });
+    });
+
+    it('tracks separately per address', () => {
+      service.onMessageRead('alice', 'msg-1', 1000);
+      service.onMessageRead('bob', 'msg-2', 2000);
+      expect(service.flushReadForPiggyback('alice')).toEqual({ messageId: 'msg-1', timestamp: 1000 });
+      expect(service.flushReadForPiggyback('bob')).toEqual({ messageId: 'msg-2', timestamp: 2000 });
+    });
+  });
+
+  describe('flushReadForPiggyback', () => {
+    it('clears the high-water mark and cancels timer', () => {
+      service.onMessageRead('alice', 'msg-1', 1000);
+      service.flushReadForPiggyback('alice');
+      expect(service.flushReadForPiggyback('alice')).toBeNull();
+      vi.advanceTimersByTime(10000);
+      expect(mockReadFlushCallback).not.toHaveBeenCalled();
+    });
+
+    it('returns null if no pending read ack', () => {
+      expect(service.flushReadForPiggyback('alice')).toBeNull();
+    });
+  });
+
+  describe('read ack timer-based flush', () => {
+    it('calls onReadFlush after 5 seconds if no piggyback', () => {
+      service.onMessageRead('alice', 'msg-1', 1000);
+      vi.advanceTimersByTime(5000);
+      expect(mockReadFlushCallback).toHaveBeenCalledWith('alice', { messageId: 'msg-1', timestamp: 1000 });
+    });
+
+    it('does not call onReadFlush before 5 seconds', () => {
+      service.onMessageRead('alice', 'msg-1', 1000);
+      vi.advanceTimersByTime(4999);
+      expect(mockReadFlushCallback).not.toHaveBeenCalled();
+    });
+
+    it('resets timer when higher timestamp arrives', () => {
+      service.onMessageRead('alice', 'msg-1', 1000);
+      vi.advanceTimersByTime(3000);
+      service.onMessageRead('alice', 'msg-2', 2000);
+      vi.advanceTimersByTime(3000);
+      expect(mockReadFlushCallback).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(2000);
+      expect(mockReadFlushCallback).toHaveBeenCalledWith('alice', { messageId: 'msg-2', timestamp: 2000 });
+    });
+
+    it('does NOT reset timer when lower timestamp arrives', () => {
+      service.onMessageRead('alice', 'msg-2', 2000);
+      vi.advanceTimersByTime(3000);
+      service.onMessageRead('alice', 'msg-1', 1000);
+      vi.advanceTimersByTime(2000);
+      expect(mockReadFlushCallback).toHaveBeenCalledWith('alice', { messageId: 'msg-2', timestamp: 2000 });
+    });
+  });
+
+  describe('flushAll with read acks', () => {
+    it('flushes both delivery and read buffers', () => {
+      service.onMessageReceived('alice', 'msg-1');
+      service.onMessageRead('alice', 'msg-2', 2000);
+      service.onMessageRead('bob', 'msg-3', 3000);
+      service.flushAll();
+      expect(mockFlushCallback).toHaveBeenCalledWith('alice', ['msg-1']);
+      expect(mockReadFlushCallback).toHaveBeenCalledWith('alice', { messageId: 'msg-2', timestamp: 2000 });
+      expect(mockReadFlushCallback).toHaveBeenCalledWith('bob', { messageId: 'msg-3', timestamp: 3000 });
+    });
+
+    it('clears read timers after flushAll', () => {
+      service.onMessageRead('alice', 'msg-1', 1000);
+      service.flushAll();
+      vi.advanceTimersByTime(10000);
+      expect(mockReadFlushCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('clearReadBuffer', () => {
+    it('discards pending read buffer without flushing', () => {
+      service.onMessageRead('alice', 'msg-1', 1000);
+      service.clearReadBuffer();
+      expect(service.flushReadForPiggyback('alice')).toBeNull();
+      vi.advanceTimersByTime(10000);
+      expect(mockReadFlushCallback).not.toHaveBeenCalled();
+    });
+
+    it('leaves delivery buffer intact after clearing read buffer', () => {
+      service.onMessageReceived('alice', 'msg-delivery-1');
+      service.onMessageRead('alice', 'msg-read-1', 1000);
+      service.clearReadBuffer();
+      expect(service.flushReadForPiggyback('alice')).toBeNull();
+      expect(service.flushForPiggyback('alice')).toEqual(['msg-delivery-1']);
+    });
+  });
+});
+
+describe('DOM event listeners', () => {
+  let service: ReceiptService;
+  let mockFlushCallback: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockFlushCallback = vi.fn();
+    service = new ReceiptService({ onFlush: mockFlushCallback as never });
+  });
+
+  afterEach(() => {
+    service.destroy();
+  });
+
+  it('calls flushAll when visibilitychange fires with hidden state', () => {
+    const flushSpy = vi.spyOn(service, 'flushAll');
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(flushSpy).toHaveBeenCalled();
+  });
+
+  it('does not call flushAll when visibilitychange fires with visible state', () => {
+    const flushSpy = vi.spyOn(service, 'flushAll');
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(flushSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls flushAll when beforeunload fires', () => {
+    const flushSpy = vi.spyOn(service, 'flushAll');
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    window.dispatchEvent(new Event('beforeunload'));
+    expect(flushSpy).toHaveBeenCalled();
+  });
+});
+
+describe('destroy() cleanup', () => {
+  let service: ReceiptService;
+  let mockFlushCallback: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockFlushCallback = vi.fn();
+  });
+
+  it('prevents visibilitychange from triggering flushAll after destroy', () => {
+    service = new ReceiptService({ onFlush: mockFlushCallback as never });
+    service.destroy();
+    service.onMessageReceived('alice', 'msg-1');
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(mockFlushCallback).not.toHaveBeenCalled();
+  });
+
+  it('prevents beforeunload from triggering flushAll after destroy', () => {
+    service = new ReceiptService({ onFlush: mockFlushCallback as never });
+    service.destroy();
+    service.onMessageReceived('alice', 'msg-1');
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    window.dispatchEvent(new Event('beforeunload'));
+    expect(mockFlushCallback).not.toHaveBeenCalled();
+  });
+});
+
+describe('Edge cases', () => {
+  let service: ReceiptService;
+  let mockFlushCallback: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockFlushCallback = vi.fn();
+    service = new ReceiptService({ onFlush: mockFlushCallback as never });
+  });
+
+  afterEach(() => {
+    service.destroy();
+  });
+
+  it('flushAll does not call onFlush when all delivery buffers are empty', () => {
+    service.flushAll();
+    expect(mockFlushCallback).not.toHaveBeenCalled();
+  });
+
+  it('onMessageRead ignores equal timestamp and keeps original messageId as HWM', () => {
+    service.onMessageRead('alice', 'msg-1', 1000);
+    service.onMessageRead('alice', 'msg-2', 1000);
+    const result = service.flushReadForPiggyback('alice');
+    expect(result).toEqual({ messageId: 'msg-1', timestamp: 1000 });
+  });
+});

--- a/src/receipts/service.ts
+++ b/src/receipts/service.ts
@@ -1,0 +1,216 @@
+/**
+ * ReceiptService
+ *
+ * Manages the ack buffer for delivery receipts and read receipts. Coordinates:
+ * - Buffering messageIds when DMs are decrypted (delivery acks)
+ * - Tracking read high-water mark per address (read acks)
+ * - Piggybacking acks on outgoing DMs
+ * - Timer-based standalone ack flush (10s delivery, 5s read)
+ * - Flush-all on app backgrounding
+ *
+ * Platform-agnostic: the constructor takes callbacks for the platform-specific
+ * pieces (encrypted send, React Query cache updates, etc.). DOM access for the
+ * background-flush listener is guarded with `typeof document` / `typeof window`
+ * checks so the same code runs unchanged on React Native, where the listener
+ * is simply skipped and the caller wires their own foreground-change signal.
+ */
+
+const DELIVERY_FLUSH_TIMEOUT_MS = 10_000;
+const READ_FLUSH_TIMEOUT_MS = 5_000;
+
+type ReadHighWaterMark = { messageId: string; timestamp: number };
+
+export interface ReceiptServiceOptions {
+  /** Called when delivery ack buffer needs to be flushed */
+  onFlush: (address: string, messageIds: string[]) => void;
+  /** Called when incoming delivery acks are received */
+  onAckProcessed?: (messageIds: string[]) => void;
+  /** Called when read ack high-water mark needs to be flushed */
+  onReadFlush?: (address: string, highWaterMark: ReadHighWaterMark) => void;
+  /** Called when incoming read acks are received. conversationAddress is the DM partner's address. */
+  onReadAckProcessed?: (upToMessageId: string, upToTimestamp: number, conversationAddress: string) => void;
+}
+
+export class ReceiptService {
+  private buffers = new Map<string, Set<string>>();
+  private timers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readHighWaterMarks = new Map<string, ReadHighWaterMark>();
+  private readTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private options: ReceiptServiceOptions;
+  private visibilityHandler: (() => void) | null = null;
+
+  constructor(options: ReceiptServiceOptions) {
+    this.options = options;
+    this.setupVisibilityListener();
+  }
+
+  // === Delivery Ack Methods (unchanged) ===
+
+  onMessageReceived(address: string, messageId: string): void {
+    let buffer = this.buffers.get(address);
+    if (!buffer) {
+      buffer = new Set();
+      this.buffers.set(address, buffer);
+    }
+    buffer.add(messageId);
+    this.resetDeliveryTimer(address);
+  }
+
+  flushForPiggyback(address: string): string[] {
+    const buffer = this.buffers.get(address);
+    if (!buffer || buffer.size === 0) return [];
+
+    const ids = Array.from(buffer);
+    this.clearDeliveryAddress(address);
+    return ids;
+  }
+
+  onAckReceived(messageIds: string[]): void {
+    if (messageIds.length > 0 && this.options.onAckProcessed) {
+      this.options.onAckProcessed(messageIds);
+    }
+  }
+
+  // === Read Ack Methods ===
+
+  /**
+   * Record that a message was read. Updates high-water mark if timestamp is higher.
+   * Caller must check readReceipts setting BEFORE calling this.
+   */
+  onMessageRead(address: string, messageId: string, timestamp: number): void {
+    const existing = this.readHighWaterMarks.get(address);
+    if (existing && existing.timestamp >= timestamp) return;
+
+    this.readHighWaterMarks.set(address, { messageId, timestamp });
+    this.resetReadTimer(address);
+  }
+
+  flushReadForPiggyback(address: string): ReadHighWaterMark | null {
+    const hwm = this.readHighWaterMarks.get(address);
+    if (!hwm) return null;
+
+    this.clearReadAddress(address);
+    return hwm;
+  }
+
+  onReadAckReceived(upToMessageId: string, upToTimestamp: number, conversationAddress: string): void {
+    if (this.options.onReadAckProcessed) {
+      this.options.onReadAckProcessed(upToMessageId, upToTimestamp, conversationAddress);
+    }
+  }
+
+  clearReadBuffer(): void {
+    for (const timer of this.readTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.readHighWaterMarks.clear();
+    this.readTimers.clear();
+  }
+
+  // === Shared Methods ===
+
+  flushAll(): void {
+    for (const [address, buffer] of this.buffers) {
+      if (buffer.size > 0) {
+        this.options.onFlush(address, Array.from(buffer));
+      }
+    }
+    if (this.options.onReadFlush) {
+      for (const [address, hwm] of this.readHighWaterMarks) {
+        this.options.onReadFlush(address, hwm);
+      }
+    }
+    this.clearAll();
+  }
+
+  destroy(): void {
+    this.clearAll();
+    if (this.visibilityHandler) {
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', this.visibilityHandler);
+      }
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('beforeunload', this.visibilityHandler);
+      }
+    }
+  }
+
+  // === Private ===
+
+  private resetDeliveryTimer(address: string): void {
+    const existing = this.timers.get(address);
+    if (existing) clearTimeout(existing);
+
+    this.timers.set(
+      address,
+      setTimeout(() => {
+        const buffer = this.buffers.get(address);
+        if (buffer && buffer.size > 0) {
+          this.options.onFlush(address, Array.from(buffer));
+          this.clearDeliveryAddress(address);
+        }
+      }, DELIVERY_FLUSH_TIMEOUT_MS),
+    );
+  }
+
+  private resetReadTimer(address: string): void {
+    const existing = this.readTimers.get(address);
+    if (existing) clearTimeout(existing);
+
+    this.readTimers.set(
+      address,
+      setTimeout(() => {
+        const hwm = this.readHighWaterMarks.get(address);
+        if (hwm && this.options.onReadFlush) {
+          this.options.onReadFlush(address, hwm);
+          this.clearReadAddress(address);
+        }
+      }, READ_FLUSH_TIMEOUT_MS),
+    );
+  }
+
+  private clearDeliveryAddress(address: string): void {
+    this.buffers.delete(address);
+    const timer = this.timers.get(address);
+    if (timer) {
+      clearTimeout(timer);
+      this.timers.delete(address);
+    }
+  }
+
+  private clearReadAddress(address: string): void {
+    this.readHighWaterMarks.delete(address);
+    const timer = this.readTimers.get(address);
+    if (timer) {
+      clearTimeout(timer);
+      this.readTimers.delete(address);
+    }
+  }
+
+  private clearAll(): void {
+    for (const timer of this.timers.values()) {
+      clearTimeout(timer);
+    }
+    this.buffers.clear();
+    this.timers.clear();
+    for (const timer of this.readTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.readHighWaterMarks.clear();
+    this.readTimers.clear();
+  }
+
+  private setupVisibilityListener(): void {
+    if (typeof document === 'undefined') return;
+
+    this.visibilityHandler = () => {
+      if (document.visibilityState === 'hidden') {
+        this.flushAll();
+      }
+    };
+    document.addEventListener('visibilitychange', this.visibilityHandler);
+    if (typeof window !== 'undefined') {
+      window.addEventListener('beforeunload', this.visibilityHandler);
+    }
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -73,6 +73,8 @@ export type {
 export type {
   DeliveryAckMessage,
   ReadAckMessage,
+  ReceiptControlMessage,
+  ReceiptControlMessageType,
   ReceiptEnvelopeFields,
 } from './receipt';
 

--- a/src/types/receipt.ts
+++ b/src/types/receipt.ts
@@ -31,6 +31,15 @@ export type ReadAckMessage = {
 };
 
 /**
+ * Discriminated union of all standalone receipt control messages.
+ * Use this to narrow `raw.type` inside the decrypt-layer intercept.
+ */
+export type ReceiptControlMessage = DeliveryAckMessage | ReadAckMessage;
+
+/** String-literal discriminator for ReceiptControlMessage. */
+export type ReceiptControlMessageType = ReceiptControlMessage['type'];
+
+/**
  * Envelope-level fields for piggybacking receipt data on outgoing DMs.
  * These ride along with regular messages and are stripped before persistence.
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,38 @@
 # yarn lockfile v1
 
 
+"@asamuzakjp/css-color@^5.1.11":
+  version "5.1.11"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-5.1.11.tgz#28a0aac8220a4cc19045ac3bd9a813d4060bd375"
+  integrity sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==
+  dependencies:
+    "@asamuzakjp/generational-cache" "^1.0.1"
+    "@csstools/css-calc" "^3.2.0"
+    "@csstools/css-color-parser" "^4.1.0"
+    "@csstools/css-parser-algorithms" "^4.0.0"
+    "@csstools/css-tokenizer" "^4.0.0"
+
+"@asamuzakjp/dom-selector@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz#01880086bb2490098f167beb58555da1a6c9adbd"
+  integrity sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==
+  dependencies:
+    "@asamuzakjp/generational-cache" "^1.0.1"
+    "@asamuzakjp/nwsapi" "^2.3.9"
+    bidi-js "^1.0.3"
+    css-tree "^3.2.1"
+    is-potential-custom-element-name "^1.0.1"
+
+"@asamuzakjp/generational-cache@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz#3d0bf6be4fc059851390a7070720c6007af793ec"
+  integrity sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==
+
+"@asamuzakjp/nwsapi@^2.3.9":
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz#ad5549322dfe9d153d4b4dd6f7ff2ae234b06e24"
+  integrity sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==
+
 "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz"
@@ -261,6 +293,46 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz"
   integrity sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==
 
+"@bramus/specificity@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@bramus/specificity/-/specificity-2.4.2.tgz#aa8db8eb173fdee7324f82284833106adeecc648"
+  integrity sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==
+  dependencies:
+    css-tree "^3.0.0"
+
+"@csstools/color-helpers@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-6.0.2.tgz#82c59fd30649cf0b4d3c82160489748666e6550b"
+  integrity sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==
+
+"@csstools/css-calc@^3.2.0", "@csstools/css-calc@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@csstools/css-calc/-/css-calc-3.2.1.tgz#b30e061ca9f297ccb2b3b032bfee32fda02b1b27"
+  integrity sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==
+
+"@csstools/css-color-parser@^4.1.0":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz#70c322112e2aafb0b09f34b51ce3482db6aab2ac"
+  integrity sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==
+  dependencies:
+    "@csstools/color-helpers" "^6.0.2"
+    "@csstools/css-calc" "^3.2.1"
+
+"@csstools/css-parser-algorithms@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz#e1c65dc09378b42f26a111fca7f7075fc2c26164"
+  integrity sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==
+
+"@csstools/css-syntax-patches-for-csstree@^1.1.3":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz#8f4e5e23574e8c76005588984308d2b216993720"
+  integrity sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==
+
+"@csstools/css-tokenizer@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz#798a33950d11226a0ebb6acafa60f5594424967f"
+  integrity sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==
+
 "@emnapi/core@^1.7.1":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.0.tgz#4a54213b208fcf288cce25076c74e0f7613e6100"
@@ -412,6 +484,11 @@
   version "0.27.2"
   resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz"
   integrity sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==
+
+"@exodus/bytes@^1.11.0", "@exodus/bytes@^1.15.0", "@exodus/bytes@^1.6.0":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@exodus/bytes/-/bytes-1.15.0.tgz#54479e0f406cbad024d6fe1c3190ecca4468df3b"
+  integrity sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==
 
 "@floating-ui/core@^1.7.5":
   version "1.7.5"
@@ -1364,6 +1441,13 @@ baseline-browser-mapping@^2.9.0:
   resolved "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz"
   integrity sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==
 
+bidi-js@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bidi-js/-/bidi-js-1.0.3.tgz#6f8bcf3c877c4d9220ddf49b9bb6930c88f877d2"
+  integrity sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==
+  dependencies:
+    require-from-string "^2.0.2"
+
 brace-expansion@^1.1.7:
   version "1.1.12"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz"
@@ -1567,10 +1651,26 @@ convert-source-map@^2.0.0:
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+css-tree@^3.0.0, css-tree@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-3.2.1.tgz#86cac7011561272b30e6b1e042ba6ce047aa7518"
+  integrity sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==
+  dependencies:
+    mdn-data "2.27.1"
+    source-map-js "^1.2.1"
+
 csstype@^3.2.2:
   version "3.2.3"
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
+
+data-urls@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-7.0.0.tgz#6dce8b63226a1ecfdd907ce18a8ccfb1eee506d3"
+  integrity sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==
+  dependencies:
+    whatwg-mimetype "^5.0.0"
+    whatwg-url "^16.0.0"
 
 dayjs@^1.11.19:
   version "1.11.20"
@@ -1590,6 +1690,11 @@ debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.3.1, debug@^4.4.0:
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
+
+decimal.js@^10.6.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
+  integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
 
 decode-named-character-reference@^1.0.0:
   version "1.3.0"
@@ -1649,6 +1754,11 @@ encodeurl@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
+entities@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-8.0.0.tgz#c1df5fe3602429747fa233d0dd26f142f0ce4743"
+  integrity sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==
 
 error-stack-parser@^2.0.6:
   version "2.1.4"
@@ -1920,6 +2030,13 @@ hermes-parser@0.33.3:
   dependencies:
     hermes-estree "0.33.3"
 
+html-encoding-sniffer@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz#f8d9390b3b348b50d4f61c16dd2ef5c05980a882"
+  integrity sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==
+  dependencies:
+    "@exodus/bytes" "^1.6.0"
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz"
@@ -2000,6 +2117,11 @@ is-plain-obj@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
+
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
 
 is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
@@ -2173,6 +2295,33 @@ jsc-safe-url@^0.2.2:
   resolved "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz"
   integrity sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==
 
+jsdom@^29.1.1:
+  version "29.1.1"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-29.1.1.tgz#5b9704906f3cd510c34aa941ae2f8f7f8179df01"
+  integrity sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==
+  dependencies:
+    "@asamuzakjp/css-color" "^5.1.11"
+    "@asamuzakjp/dom-selector" "^7.1.1"
+    "@bramus/specificity" "^2.4.2"
+    "@csstools/css-syntax-patches-for-csstree" "^1.1.3"
+    "@exodus/bytes" "^1.15.0"
+    css-tree "^3.2.1"
+    data-urls "^7.0.0"
+    decimal.js "^10.6.0"
+    html-encoding-sniffer "^6.0.0"
+    is-potential-custom-element-name "^1.0.1"
+    lru-cache "^11.3.5"
+    parse5 "^8.0.1"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^6.0.1"
+    undici "^7.25.0"
+    w3c-xmlserializer "^5.0.0"
+    webidl-conversions "^8.0.1"
+    whatwg-mimetype "^5.0.0"
+    whatwg-url "^16.0.1"
+    xml-name-validator "^5.0.0"
+
 jsesc@^3.0.2:
   version "3.1.0"
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz"
@@ -2308,6 +2457,11 @@ loose-envify@^1.0.0, loose-envify@^1.4.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+lru-cache@^11.3.5:
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.5.0.tgz#14117229fd25bc9c67936e32de90ca047488c97a"
+  integrity sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -2478,6 +2632,11 @@ mdast-util-to-string@^4.0.0:
   integrity sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==
   dependencies:
     "@types/mdast" "^4.0.0"
+
+mdn-data@2.27.1:
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.27.1.tgz#e37b9c50880b75366c4d40ac63d9bbcacdb61f0e"
+  integrity sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==
 
 memoize-one@^5.0.0:
   version "5.2.1"
@@ -3132,6 +3291,13 @@ p-try@^2.0.0:
   resolved "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+parse5@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-8.0.1.tgz#f43bcd2cd683efe084075333e9ce0da7d06da31e"
+  integrity sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==
+  dependencies:
+    entities "^8.0.0"
+
 parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz"
@@ -3221,6 +3387,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+punycode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 queue@6.0.2:
   version "6.0.2"
@@ -3377,6 +3548,11 @@ require-directory@^2.1.1:
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz"
@@ -3443,6 +3619,13 @@ rollup@^4.34.8:
     "@rollup/rollup-win32-x64-gnu" "4.54.0"
     "@rollup/rollup-win32-x64-msvc" "4.54.0"
     fsevents "~2.3.2"
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
 
 scheduler@0.26.0, scheduler@^0.26.0:
   version "0.26.0"
@@ -3640,6 +3823,11 @@ supports-color@^8.0.0:
   dependencies:
     has-flag "^4.0.0"
 
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 terser@^5.15.0:
   version "5.46.0"
   resolved "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz"
@@ -3706,6 +3894,18 @@ tinyrainbow@^3.0.3:
   resolved "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz"
   integrity sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==
 
+tldts-core@^7.0.30:
+  version "7.0.30"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-7.0.30.tgz#c495dba27778f2220bea94f3f6399005c7aca61c"
+  integrity sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==
+
+tldts@^7.0.5:
+  version "7.0.30"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-7.0.30.tgz#497cea8d610953222f9dcb3ceb07c7207efcd816"
+  integrity sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==
+  dependencies:
+    tldts-core "^7.0.30"
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz"
@@ -3722,6 +3922,20 @@ toidentifier@~1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+tough-cookie@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-6.0.1.tgz#a495f833836609ed983c19bc65639cfbceb54c76"
+  integrity sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==
+  dependencies:
+    tldts "^7.0.5"
+
+tr46@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-6.0.0.tgz#f5a1ae546a0adb32a277a2278d0d17fa2f9093e6"
+  integrity sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==
+  dependencies:
+    punycode "^2.3.1"
 
 tree-kill@^1.2.2:
   version "1.2.2"
@@ -3790,6 +4004,11 @@ undici-types@~7.18.0:
   version "7.18.2"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz"
   integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
+
+undici@^7.25.0:
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.25.0.tgz#7d72fc429a0421769ca2966fd07cac875c85b781"
+  integrity sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==
 
 unified@^11.0.0:
   version "11.0.5"
@@ -3919,6 +4138,13 @@ vlq@^1.0.0:
   resolved "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz"
   integrity sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==
 
+w3c-xmlserializer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"
+  integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
+  dependencies:
+    xml-name-validator "^5.0.0"
+
 walker@^1.0.7, walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz"
@@ -3926,10 +4152,29 @@ walker@^1.0.7, walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
+webidl-conversions@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-8.0.1.tgz#0657e571fe6f06fcb15ca50ed1fdbcb495cd1686"
+  integrity sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==
+
 whatwg-fetch@^3.0.0:
   version "3.6.20"
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz"
   integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==
+
+whatwg-mimetype@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz#d8232895dbd527ceaee74efd4162008fb8a8cf48"
+  integrity sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==
+
+whatwg-url@^16.0.0, whatwg-url@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-16.0.1.tgz#047f7f4bd36ef76b7198c172d1b1cebc66f764dd"
+  integrity sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==
+  dependencies:
+    "@exodus/bytes" "^1.11.0"
+    tr46 "^6.0.0"
+    webidl-conversions "^8.0.1"
 
 why-is-node-running@^2.3.0:
   version "2.3.0"
@@ -3972,6 +4217,16 @@ ws@^7, ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+
+xml-name-validator@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
+  integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
## Summary

Migrates the delivery + read receipt protocol from quorum-desktop into the shared package. Mobile (and any future consumer) can now instantiate `ReceiptService` directly instead of reimplementing it; the wire protocol (`DeliveryAckMessage`, `ReadAckMessage`) is now codified in one place across platforms.

## What changed

- `src/receipts/service.ts` — `ReceiptService` class (204 lines, copied verbatim from desktop's `src/services/ReceiptService.ts` except for a small symmetry fix: the public `window.removeEventListener` in `destroy()` is now wrapped in `typeof window !== 'undefined'` to match the guard already present in `setupVisibilityListener`)
- `src/receipts/service.test.ts` — 35 unit tests (verbatim copy of the desktop test file, with `// @vitest-environment jsdom` per-file pragma so the DOM `visibilitychange` / `beforeunload` tests work against shared's node-default vitest env)
- `src/receipts/index.ts` — barrel re-exporting `ReceiptService` + `ReceiptServiceOptions`
- `src/types/receipt.ts` — added `ReceiptControlMessage` (discriminated union of `DeliveryAckMessage | ReadAckMessage`) and `ReceiptControlMessageType` alias. `DeliveryAckMessage`, `ReadAckMessage`, and `ReceiptEnvelopeFields` were already there from an earlier prep PR.
- `src/types/index.ts` and `src/index.ts` updated to re-export the new symbols
- `jsdom` added as a devDependency for the test-environment override
- Version bump: `2.1.0-12` → `2.1.0-13`
- README updated with the new `Receipts` module entry and folder

## Notes on the wire format

The companion desktop PR drops a defensive `raw.content?.type` fallback in `MessageService.processDeliveryReceiptData`. Investigation during this migration confirmed only the **flat** shape ever existed on the wire (one sender path in `ActionQueueHandlers`, always flat); the nested-shape branches in the receiver were dead defensive code from the original receiver bug (see `.agents/bugs/.solved/2026-03-19-standalone-delivery-ack-unreliable.md` line 28 on the desktop side). So the shared `DeliveryAckMessage` / `ReadAckMessage` types codify the only shape that ever flies. No mobile compatibility surprise.

## Pairs with

quorum-desktop PR: `refactor(receipts): consume ReceiptService from quorum-shared` (receipts-shared-migration branch).

## Test plan

- [x] `yarn build` clean — all 3 outputs (`index.mjs`, `index.js`, `index.native.js`) generated
- [x] `yarn test --run src/receipts/` — 35/35 pass
- [ ] Manual two-account QA on desktop after merge: delivery checkmarks (✓ → ✓✓) and read receipts (✓✓ → ✓✓ blue) still work end-to-end — currently blocked on an unrelated DM sync issue in the dev environment