### PR TITLE
feat: add useTwoStepConfirm hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-17",
+  "version": "2.1.0-18",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,13 @@
 /**
- * Shared React Query hooks
+ * Shared React hooks
  */
+
+// UI primitives
+export { useTwoStepConfirm } from './useTwoStepConfirm';
+export type {
+  UseTwoStepConfirmOptions,
+  UseTwoStepConfirmResult,
+} from './useTwoStepConfirm';
 
 // Query keys
 export { queryKeys } from './keys';

--- a/src/hooks/useTwoStepConfirm.ts
+++ b/src/hooks/useTwoStepConfirm.ts
@@ -1,0 +1,108 @@
+/**
+ * useTwoStepConfirm
+ *
+ * Two-step confirmation primitive for destructive actions. First call to
+ * `armOrConfirm` arms the confirmation (sets step to 1) and starts a
+ * timeout; the second call within the timeout window executes the action.
+ * If the timeout elapses, the state resets and the next call re-arms.
+ *
+ * Extracted from desktop's `useUserKicking` and `useSpaceLeaving`, which
+ * each inlined the same state machine. Mobile's `useUserKicking` inlined
+ * the identical pattern. This hook is the shared primitive; consumers on
+ * either platform can adopt it incrementally.
+ *
+ * Uses `ReturnType<typeof setTimeout>` for the timeout handle so it works
+ * in both browser and React Native runtimes without ambient `NodeJS.*`
+ * types.
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+export interface UseTwoStepConfirmOptions {
+  /**
+   * Milliseconds the armed state stays active before auto-resetting.
+   * Default: 5000.
+   */
+  timeoutMs?: number;
+}
+
+export interface UseTwoStepConfirmResult {
+  /**
+   * Current step. 0 = idle, 1 = armed (one click away from confirmation).
+   */
+  confirmationStep: 0 | 1;
+
+  /**
+   * Arm on first call, confirm on second.
+   *
+   * - If `confirmationStep` is 0: arms the confirmation and starts the
+   *   auto-reset timeout. Does NOT invoke `onConfirm`.
+   * - If `confirmationStep` is 1: clears the timeout and invokes
+   *   `onConfirm`. The caller is responsible for awaiting its result.
+   *
+   * `onConfirm` may return a promise; the hook does not await it. State
+   * resets to idle as soon as the second call fires.
+   */
+  armOrConfirm: (onConfirm: () => void | Promise<void>) => void;
+
+  /**
+   * Cancel any in-flight arming and reset to step 0.
+   */
+  resetConfirmation: () => void;
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+export function useTwoStepConfirm(
+  options: UseTwoStepConfirmOptions = {}
+): UseTwoStepConfirmResult {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const [confirmationStep, setConfirmationStep] = useState<0 | 1>(0);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear any pending timeout on unmount so we don't try to set state on
+  // an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const clearPendingTimeout = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const resetConfirmation = useCallback(() => {
+    clearPendingTimeout();
+    setConfirmationStep(0);
+  }, [clearPendingTimeout]);
+
+  const armOrConfirm = useCallback(
+    (onConfirm: () => void | Promise<void>) => {
+      if (confirmationStep === 0) {
+        setConfirmationStep(1);
+        clearPendingTimeout();
+        timeoutRef.current = setTimeout(() => {
+          timeoutRef.current = null;
+          setConfirmationStep(0);
+        }, timeoutMs);
+      } else {
+        clearPendingTimeout();
+        setConfirmationStep(0);
+        onConfirm();
+      }
+    },
+    [confirmationStep, timeoutMs, clearPendingTimeout]
+  );
+
+  return {
+    confirmationStep,
+    armOrConfirm,
+    resetConfirmation,
+  };
+}


### PR DESCRIPTION
## What

New cross-platform two-step confirmation primitive at `src/hooks/useTwoStepConfirm.ts`. First call to `armOrConfirm` arms the confirmation (sets step to 1) and starts a timeout; the second call within the window invokes the supplied callback. If the timeout elapses, state auto-resets.

## Cross-repo migration

This is part of a 2-repo change:
- **quorum-shared** (this PR): adds `useTwoStepConfirm` (additive only)
- **quorum-desktop**: refactors `useUserKicking` + `useSpaceLeaving` to consume the shared hook (PR will follow once this merges)
- **quorum-mobile**: no PR planned in this batch. Mobile's `hooks/chat/useUserKicking.ts` still inlines the identical state machine; could adopt the shared primitive in a future ~5-LOC PR (deferred because it touches runtime code, requires testing the mobile app).

## Why

Desktop had the same two-step \"arm-then-confirm-within-5s\" state machine inlined in two hooks (`useUserKicking`, `useSpaceLeaving`), and mobile's `useUserKicking` inlines the character-identical pattern (verified line-by-line against `quorum-mobile/origin/master 98d59a4`). The hooks audit refresh ([quorum-desktop .agents/tasks/quorum-shared-migration/designs/2026-05-28-hooks-audit-refresh.md](https://github.com/QuilibriumNetwork/quorum-desktop/blob/feat/use-two-step-confirm/.agents/tasks/quorum-shared-migration/designs/2026-05-28-hooks-audit-refresh.md)) flagged this as a candidate for extraction.

## Compatibility

- **Additive only.** No existing exports changed. Per the additive-vs-breaking gut-check: if a consumer bumped `@quilibrium/quorum-shared` to `2.1.0-18` right now without any other code changes, it would still build.
- Uses `ReturnType<typeof setTimeout>` for the timeout handle so it works in both browser and React Native runtimes without ambient `NodeJS.*` types (mobile already uses this pattern).

## Verification

- [x] `yarn build` (CJS + ESM + native targets)
- [x] `yarn test` (189 tests pass — no new tests added; shared has no React testing-library set up yet, hook tested via desktop integration)