### PR TITLE
feat: add field validators with errorKey i18n pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-18",
+  "version": "2.1.0-19",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,3 +42,6 @@ export * from './primitives';
 
 // Farcaster (hypersnap-first, legacy-fallback)
 export * from './farcaster';
+
+// Validation (errorKey-pattern field validators)
+export * from './validation';

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -40,9 +40,17 @@ export const DANGEROUS_HTML_PATTERN = /<[a-zA-Z\/!?]/;
 
 /**
  * Maximum length for user input names (display names, space names, group names, channel names)
- * Centralized constant to ensure consistency across the application
+ * Centralized constant to ensure consistency across the application.
+ *
+ * Aligned to mobile's value (2026-05-28) per the "follow mobile patterns" workflow rule.
  */
-export const MAX_NAME_LENGTH = 40;
+export const MAX_NAME_LENGTH = 50;
+
+/**
+ * Minimum length for user input names (display names, space names, etc.).
+ * Aligned to mobile's value (2026-05-28).
+ */
+export const MIN_NAME_LENGTH = 2;
 
 /**
  * Maximum length for topic/description fields (channel topics, space descriptions)

--- a/src/validation/channelName.ts
+++ b/src/validation/channelName.ts
@@ -1,0 +1,31 @@
+/**
+ * Channel name validation.
+ *
+ * Rules:
+ * - Required (non-empty after trim)
+ * - Maximum length: MAX_NAME_LENGTH
+ * - No dangerous HTML patterns (XSS defense-in-depth)
+ *
+ * Channels do not enforce MIN_NAME_LENGTH today (single-character channels
+ * like "#1" or emoji-prefixed names should remain valid).
+ */
+
+import { MAX_NAME_LENGTH, validateNameForXSS } from '../utils/validation';
+import type { FieldValidationResult } from './result';
+
+export function validateChannelName(channelName: string): FieldValidationResult {
+  if (!channelName.trim()) {
+    return { ok: false, errorKey: 'channelName.required' };
+  }
+  if (channelName.length > MAX_NAME_LENGTH) {
+    return {
+      ok: false,
+      errorKey: 'channelName.tooLong',
+      errorVars: { max: MAX_NAME_LENGTH },
+    };
+  }
+  if (!validateNameForXSS(channelName)) {
+    return { ok: false, errorKey: 'channelName.invalidChars' };
+  }
+  return { ok: true };
+}

--- a/src/validation/channelTopic.ts
+++ b/src/validation/channelTopic.ts
@@ -1,0 +1,25 @@
+/**
+ * Channel topic validation.
+ *
+ * Rules:
+ * - Optional (empty is valid)
+ * - Maximum length: MAX_TOPIC_LENGTH
+ * - No dangerous HTML patterns when non-empty (XSS defense-in-depth)
+ */
+
+import { MAX_TOPIC_LENGTH, validateNameForXSS } from '../utils/validation';
+import type { FieldValidationResult } from './result';
+
+export function validateChannelTopic(channelTopic: string): FieldValidationResult {
+  if (channelTopic.length > MAX_TOPIC_LENGTH) {
+    return {
+      ok: false,
+      errorKey: 'channelTopic.tooLong',
+      errorVars: { max: MAX_TOPIC_LENGTH },
+    };
+  }
+  if (channelTopic && !validateNameForXSS(channelTopic)) {
+    return { ok: false, errorKey: 'channelTopic.invalidChars' };
+  }
+  return { ok: true };
+}

--- a/src/validation/deviceName.ts
+++ b/src/validation/deviceName.ts
@@ -1,0 +1,35 @@
+/**
+ * Device name validation.
+ *
+ * Rules:
+ * - Required (non-empty after trim)
+ * - Maximum length: MAX_NAME_LENGTH
+ * - No dangerous HTML patterns (XSS defense-in-depth)
+ * - Restricted character set: unicode letters, unicode digits, spaces, hyphens, parentheses, apostrophes
+ */
+
+import { MAX_NAME_LENGTH, validateNameForXSS } from '../utils/validation';
+import type { FieldValidationResult } from './result';
+
+// Allowed: unicode letters, unicode digits, spaces, hyphens, parentheses, apostrophes
+export const DEVICE_NAME_PATTERN = /^[\p{L}\p{N} \-()']+$/u;
+
+export function validateDeviceName(name: string): FieldValidationResult {
+  if (!name.trim()) {
+    return { ok: false, errorKey: 'deviceName.required' };
+  }
+  if (name.length > MAX_NAME_LENGTH) {
+    return {
+      ok: false,
+      errorKey: 'deviceName.tooLong',
+      errorVars: { max: MAX_NAME_LENGTH },
+    };
+  }
+  if (!validateNameForXSS(name)) {
+    return { ok: false, errorKey: 'deviceName.invalidChars' };
+  }
+  if (!DEVICE_NAME_PATTERN.test(name)) {
+    return { ok: false, errorKey: 'deviceName.invalidCharset' };
+  }
+  return { ok: true };
+}

--- a/src/validation/displayName.ts
+++ b/src/validation/displayName.ts
@@ -1,0 +1,43 @@
+/**
+ * Display name validation.
+ *
+ * Rules (verified against mobile + pre-refactor desktop, 2026-05-28):
+ * - Required (non-empty after trim)
+ * - Maximum length: MAX_NAME_LENGTH (no minimum — mobile has no validation
+ *   on display names at all; pre-refactor desktop only required non-empty)
+ * - No mention-reserved names (everyone, here, mod, manager)
+ * - No impersonation names (admin, moderator, etc., including homoglyph variants)
+ * - No dangerous HTML patterns (XSS defense-in-depth)
+ */
+
+import {
+  MAX_NAME_LENGTH,
+  validateNameForXSS,
+  getReservedNameType,
+} from '../utils/validation';
+import type { FieldValidationResult } from './result';
+
+export function validateDisplayName(displayName: string): FieldValidationResult {
+  const trimmed = displayName.trim();
+  if (!trimmed) {
+    return { ok: false, errorKey: 'displayName.required' };
+  }
+  if (displayName.length > MAX_NAME_LENGTH) {
+    return {
+      ok: false,
+      errorKey: 'displayName.tooLong',
+      errorVars: { max: MAX_NAME_LENGTH },
+    };
+  }
+  const reservedType = getReservedNameType(displayName);
+  if (reservedType === 'mention') {
+    return { ok: false, errorKey: 'displayName.reservedMention' };
+  }
+  if (reservedType === 'impersonation') {
+    return { ok: false, errorKey: 'displayName.reservedImpersonation' };
+  }
+  if (!validateNameForXSS(displayName)) {
+    return { ok: false, errorKey: 'displayName.invalidChars' };
+  }
+  return { ok: true };
+}

--- a/src/validation/groupName.ts
+++ b/src/validation/groupName.ts
@@ -1,0 +1,25 @@
+/**
+ * Group name validation.
+ *
+ * Same shape as channel name — required, length-capped, XSS-safe.
+ */
+
+import { MAX_NAME_LENGTH, validateNameForXSS } from '../utils/validation';
+import type { FieldValidationResult } from './result';
+
+export function validateGroupName(groupName: string): FieldValidationResult {
+  if (!groupName.trim()) {
+    return { ok: false, errorKey: 'groupName.required' };
+  }
+  if (groupName.length > MAX_NAME_LENGTH) {
+    return {
+      ok: false,
+      errorKey: 'groupName.tooLong',
+      errorVars: { max: MAX_NAME_LENGTH },
+    };
+  }
+  if (!validateNameForXSS(groupName)) {
+    return { ok: false, errorKey: 'groupName.invalidChars' };
+  }
+  return { ok: true };
+}

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Cross-platform validators.
+ *
+ * Each validator returns a `ValidationResult` (or `ValidationResult[]` for
+ * multi-violation checks like bio/description). Platform consumers wrap
+ * with thin i18n adapters that map `errorKey` to displayed strings.
+ *
+ * See `.agents/tasks/quorum-shared-migration/2026-05-28-cross-repo-workflow.md`
+ * section "i18n in shared" for the rule + worked examples.
+ */
+
+export type {
+  FieldValidationOk,
+  FieldValidationErr,
+  FieldValidationResult,
+} from './result';
+export { isValidField } from './result';
+
+export { validateSpaceName } from './spaceName';
+export { validateSpaceDescription } from './spaceDescription';
+export { validateDisplayName } from './displayName';
+export { validateChannelName } from './channelName';
+export { validateChannelTopic } from './channelTopic';
+export { validateGroupName } from './groupName';
+export { validateDeviceName, DEVICE_NAME_PATTERN } from './deviceName';
+export { validateUserBio, MAX_BIO_LENGTH } from './userBio';
+export { validateUserNote, MAX_USER_NOTE_LENGTH } from './userNote';

--- a/src/validation/result.ts
+++ b/src/validation/result.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared validation result type.
+ *
+ * Validators return a structured result with a stable error code (`errorKey`)
+ * and optional interpolation variables. Platforms (desktop with Lingui,
+ * mobile with hardcoded strings or its own i18n later) own thin wrappers
+ * that map `errorKey` to displayed text.
+ *
+ * See `.agents/tasks/quorum-shared-migration/2026-05-28-cross-repo-workflow.md`
+ * section "i18n in shared" for the full rule and rationale.
+ */
+
+export type FieldValidationOk = { ok: true };
+
+export type FieldValidationErr = {
+  ok: false;
+  errorKey: string;
+  errorVars?: Record<string, string | number>;
+};
+
+export type FieldValidationResult = FieldValidationOk | FieldValidationErr;
+
+/**
+ * Helper for callers (and platform wrappers) that just want a boolean.
+ */
+export function isValidField(result: FieldValidationResult): result is FieldValidationOk {
+  return result.ok;
+}

--- a/src/validation/spaceDescription.ts
+++ b/src/validation/spaceDescription.ts
@@ -1,0 +1,29 @@
+/**
+ * Space description validation.
+ *
+ * Accepts a caller-supplied max length (the caller decides whether this is
+ * a short topic, a longer description, etc.).
+ */
+
+import { validateNameForXSS } from '../utils/validation';
+import type { FieldValidationResult } from './result';
+
+export function validateSpaceDescription(
+  description: string,
+  maxLength: number
+): FieldValidationResult[] {
+  const errors: FieldValidationResult[] = [];
+
+  if (!validateNameForXSS(description)) {
+    errors.push({ ok: false, errorKey: 'spaceDescription.invalidChars' });
+  }
+  if (description.length > maxLength) {
+    errors.push({
+      ok: false,
+      errorKey: 'spaceDescription.tooLong',
+      errorVars: { max: maxLength },
+    });
+  }
+
+  return errors;
+}

--- a/src/validation/spaceName.ts
+++ b/src/validation/spaceName.ts
@@ -1,0 +1,37 @@
+/**
+ * Space name validation.
+ *
+ * Rules (aligned to mobile 2026-05-28):
+ * - Required (non-empty after trim)
+ * - Minimum length: MIN_NAME_LENGTH
+ * - Maximum length: MAX_NAME_LENGTH
+ * - No dangerous HTML patterns (XSS defense-in-depth)
+ */
+
+import { MAX_NAME_LENGTH, MIN_NAME_LENGTH, validateNameForXSS } from '../utils/validation';
+import type { FieldValidationResult } from './result';
+
+export function validateSpaceName(spaceName: string): FieldValidationResult {
+  const trimmed = spaceName.trim();
+  if (!trimmed) {
+    return { ok: false, errorKey: 'spaceName.required' };
+  }
+  if (trimmed.length < MIN_NAME_LENGTH) {
+    return {
+      ok: false,
+      errorKey: 'spaceName.tooShort',
+      errorVars: { min: MIN_NAME_LENGTH },
+    };
+  }
+  if (spaceName.length > MAX_NAME_LENGTH) {
+    return {
+      ok: false,
+      errorKey: 'spaceName.tooLong',
+      errorVars: { max: MAX_NAME_LENGTH },
+    };
+  }
+  if (!validateNameForXSS(spaceName)) {
+    return { ok: false, errorKey: 'spaceName.invalidChars' };
+  }
+  return { ok: true };
+}

--- a/src/validation/userBio.ts
+++ b/src/validation/userBio.ts
@@ -1,0 +1,33 @@
+/**
+ * User bio validation.
+ *
+ * Returns a list of errors (a bio can fail multiple checks; we don't
+ * short-circuit on the first failure because the form may want to show
+ * all violations).
+ */
+
+import { validateNameForXSS } from '../utils/validation';
+import type { FieldValidationResult } from './result';
+
+/**
+ * Maximum length for user bio/description.
+ * Matches mobile app limit for consistency.
+ */
+export const MAX_BIO_LENGTH = 160;
+
+export function validateUserBio(bio: string): FieldValidationResult[] {
+  const errors: FieldValidationResult[] = [];
+
+  if (!validateNameForXSS(bio)) {
+    errors.push({ ok: false, errorKey: 'userBio.invalidChars' });
+  }
+  if (bio.length > MAX_BIO_LENGTH) {
+    errors.push({
+      ok: false,
+      errorKey: 'userBio.tooLong',
+      errorVars: { max: MAX_BIO_LENGTH },
+    });
+  }
+
+  return errors;
+}

--- a/src/validation/userNote.ts
+++ b/src/validation/userNote.ts
@@ -1,0 +1,29 @@
+/**
+ * User note validation.
+ *
+ * Notes are private and never rendered as HTML — we only block actual
+ * script injection patterns rather than running the full XSS check.
+ */
+
+import type { FieldValidationResult } from './result';
+
+export const MAX_USER_NOTE_LENGTH = 256;
+
+const SCRIPT_INJECTION_PATTERN = /<script|<\/script|javascript:/i;
+
+export function validateUserNote(note: string): FieldValidationResult[] {
+  const errors: FieldValidationResult[] = [];
+
+  if (SCRIPT_INJECTION_PATTERN.test(note)) {
+    errors.push({ ok: false, errorKey: 'userNote.invalidContent' });
+  }
+  if (note.length > MAX_USER_NOTE_LENGTH) {
+    errors.push({
+      ok: false,
+      errorKey: 'userNote.tooLong',
+      errorVars: { max: MAX_USER_NOTE_LENGTH },
+    });
+  }
+
+  return errors;
+}

--- a/src/validation/validators.test.ts
+++ b/src/validation/validators.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateSpaceName,
+  validateSpaceDescription,
+  validateDisplayName,
+  validateChannelName,
+  validateChannelTopic,
+  validateGroupName,
+  validateDeviceName,
+  validateUserBio,
+  validateUserNote,
+  MAX_BIO_LENGTH,
+  MAX_USER_NOTE_LENGTH,
+  isValidField,
+} from './index';
+import { MAX_NAME_LENGTH, MIN_NAME_LENGTH, MAX_TOPIC_LENGTH } from '../utils/validation';
+
+describe('validateSpaceName', () => {
+  it('accepts valid names', () => {
+    expect(validateSpaceName('Cosmic Vibes')).toEqual({ ok: true });
+  });
+
+  it('rejects empty', () => {
+    expect(validateSpaceName('')).toEqual({ ok: false, errorKey: 'spaceName.required' });
+    expect(validateSpaceName('   ')).toEqual({ ok: false, errorKey: 'spaceName.required' });
+  });
+
+  it('rejects too short', () => {
+    const result = validateSpaceName('a');
+    expect(result).toEqual({
+      ok: false,
+      errorKey: 'spaceName.tooShort',
+      errorVars: { min: MIN_NAME_LENGTH },
+    });
+  });
+
+  it('rejects too long', () => {
+    const long = 'a'.repeat(MAX_NAME_LENGTH + 1);
+    expect(validateSpaceName(long)).toEqual({
+      ok: false,
+      errorKey: 'spaceName.tooLong',
+      errorVars: { max: MAX_NAME_LENGTH },
+    });
+  });
+
+  it('rejects HTML injection', () => {
+    expect(validateSpaceName('<script>x</script>')).toEqual({
+      ok: false,
+      errorKey: 'spaceName.invalidChars',
+    });
+  });
+
+  it('accepts safe special chars', () => {
+    expect(validateSpaceName('<3 home').ok).toBe(true);
+    expect(validateSpaceName(">_<;").ok).toBe(true);
+  });
+});
+
+describe('validateSpaceDescription', () => {
+  it('accepts valid description', () => {
+    expect(validateSpaceDescription('A nice place', 100)).toEqual([]);
+  });
+
+  it('returns multiple errors when multiple checks fail', () => {
+    const errors = validateSpaceDescription('<script>x</script>' + 'a'.repeat(200), 50);
+    expect(errors.length).toBe(2);
+    expect(errors.some((e) => !e.ok && e.errorKey === 'spaceDescription.invalidChars')).toBe(true);
+    expect(errors.some((e) => !e.ok && e.errorKey === 'spaceDescription.tooLong')).toBe(true);
+  });
+});
+
+describe('validateDisplayName', () => {
+  it('accepts valid names', () => {
+    expect(validateDisplayName('Jane Doe')).toEqual({ ok: true });
+  });
+
+  it('rejects empty', () => {
+    expect(validateDisplayName('')).toEqual({ ok: false, errorKey: 'displayName.required' });
+  });
+
+  it('accepts single-character names (no MIN on display names — matches mobile + pre-refactor desktop)', () => {
+    // Note: "a" gets caught as impersonation? no — "a" is too short to match any reserved pattern
+    expect(validateDisplayName('a')).toEqual({ ok: true });
+  });
+
+  it('rejects too long', () => {
+    const long = 'a'.repeat(MAX_NAME_LENGTH + 1);
+    expect(validateDisplayName(long)).toEqual({
+      ok: false,
+      errorKey: 'displayName.tooLong',
+      errorVars: { max: MAX_NAME_LENGTH },
+    });
+  });
+
+  it('rejects mention-reserved names', () => {
+    expect(validateDisplayName('everyone')).toEqual({
+      ok: false,
+      errorKey: 'displayName.reservedMention',
+    });
+  });
+
+  it('rejects impersonation names (including homoglyphs)', () => {
+    expect(validateDisplayName('admin')).toEqual({
+      ok: false,
+      errorKey: 'displayName.reservedImpersonation',
+    });
+    expect(validateDisplayName('@dmin')).toEqual({
+      ok: false,
+      errorKey: 'displayName.reservedImpersonation',
+    });
+  });
+
+  it('rejects HTML injection', () => {
+    expect(validateDisplayName('<script>x</script>')).toEqual({
+      ok: false,
+      errorKey: 'displayName.invalidChars',
+    });
+  });
+});
+
+describe('validateChannelName', () => {
+  it('accepts valid names', () => {
+    expect(validateChannelName('general')).toEqual({ ok: true });
+  });
+
+  it('accepts single-character names (no MIN check)', () => {
+    expect(validateChannelName('a')).toEqual({ ok: true });
+  });
+
+  it('rejects empty', () => {
+    expect(validateChannelName('')).toEqual({ ok: false, errorKey: 'channelName.required' });
+  });
+
+  it('rejects too long', () => {
+    const long = 'a'.repeat(MAX_NAME_LENGTH + 1);
+    expect(validateChannelName(long)).toEqual({
+      ok: false,
+      errorKey: 'channelName.tooLong',
+      errorVars: { max: MAX_NAME_LENGTH },
+    });
+  });
+
+  it('rejects HTML injection', () => {
+    expect(validateChannelName('<script>')).toEqual({
+      ok: false,
+      errorKey: 'channelName.invalidChars',
+    });
+  });
+});
+
+describe('validateChannelTopic', () => {
+  it('accepts empty topic', () => {
+    expect(validateChannelTopic('')).toEqual({ ok: true });
+  });
+
+  it('accepts valid topic', () => {
+    expect(validateChannelTopic('General discussion')).toEqual({ ok: true });
+  });
+
+  it('rejects too long', () => {
+    const long = 'a'.repeat(MAX_TOPIC_LENGTH + 1);
+    expect(validateChannelTopic(long)).toEqual({
+      ok: false,
+      errorKey: 'channelTopic.tooLong',
+      errorVars: { max: MAX_TOPIC_LENGTH },
+    });
+  });
+
+  it('rejects HTML injection (non-empty only)', () => {
+    expect(validateChannelTopic('<script>')).toEqual({
+      ok: false,
+      errorKey: 'channelTopic.invalidChars',
+    });
+  });
+});
+
+describe('validateGroupName', () => {
+  it('accepts valid names', () => {
+    expect(validateGroupName('General')).toEqual({ ok: true });
+  });
+
+  it('rejects empty', () => {
+    expect(validateGroupName('   ')).toEqual({ ok: false, errorKey: 'groupName.required' });
+  });
+
+  it('rejects too long', () => {
+    const long = 'a'.repeat(MAX_NAME_LENGTH + 1);
+    expect(validateGroupName(long)).toEqual({
+      ok: false,
+      errorKey: 'groupName.tooLong',
+      errorVars: { max: MAX_NAME_LENGTH },
+    });
+  });
+});
+
+describe('validateDeviceName', () => {
+  it('accepts valid names', () => {
+    expect(validateDeviceName("Jane's iPhone")).toEqual({ ok: true });
+    expect(validateDeviceName('Laptop (work)')).toEqual({ ok: true });
+    expect(validateDeviceName('MacBook-Pro')).toEqual({ ok: true });
+  });
+
+  it('rejects empty', () => {
+    expect(validateDeviceName('')).toEqual({ ok: false, errorKey: 'deviceName.required' });
+  });
+
+  it('rejects disallowed punctuation', () => {
+    const r1 = validateDeviceName('phone@home');
+    const r2 = validateDeviceName('phone!');
+    expect(r1.ok).toBe(false);
+    expect(r2.ok).toBe(false);
+    if (!r1.ok) expect(r1.errorKey).toBe('deviceName.invalidCharset');
+    if (!r2.ok) expect(r2.errorKey).toBe('deviceName.invalidCharset');
+  });
+
+  it('rejects HTML injection', () => {
+    // XSS check fires before charset check
+    expect(validateDeviceName('<script>')).toEqual({
+      ok: false,
+      errorKey: 'deviceName.invalidChars',
+    });
+  });
+
+  it('accepts unicode letters', () => {
+    expect(validateDeviceName('Téléphone')).toEqual({ ok: true });
+    expect(validateDeviceName('携帯電話')).toEqual({ ok: true });
+  });
+});
+
+describe('validateUserBio', () => {
+  it('accepts valid bio', () => {
+    expect(validateUserBio('Hello world')).toEqual([]);
+  });
+
+  it('rejects too long', () => {
+    const errors = validateUserBio('a'.repeat(MAX_BIO_LENGTH + 1));
+    expect(errors).toEqual([
+      { ok: false, errorKey: 'userBio.tooLong', errorVars: { max: MAX_BIO_LENGTH } },
+    ]);
+  });
+
+  it('rejects HTML injection', () => {
+    const errors = validateUserBio('<script>');
+    expect(errors[0]).toEqual({ ok: false, errorKey: 'userBio.invalidChars' });
+  });
+});
+
+describe('validateUserNote', () => {
+  it('accepts valid note', () => {
+    expect(validateUserNote('Some private thought')).toEqual([]);
+  });
+
+  it('rejects script injection patterns', () => {
+    const errors = validateUserNote('<script>alert(1)</script>');
+    expect(errors[0]).toEqual({ ok: false, errorKey: 'userNote.invalidContent' });
+  });
+
+  it('rejects javascript: pseudo-protocol', () => {
+    const errors = validateUserNote('Click javascript:alert(1)');
+    expect(errors[0]).toEqual({ ok: false, errorKey: 'userNote.invalidContent' });
+  });
+
+  it('rejects too long', () => {
+    const errors = validateUserNote('a'.repeat(MAX_USER_NOTE_LENGTH + 1));
+    expect(errors[0]).toEqual({
+      ok: false,
+      errorKey: 'userNote.tooLong',
+      errorVars: { max: MAX_USER_NOTE_LENGTH },
+    });
+  });
+
+  it('accepts angle brackets in safe contexts (notes are not HTML-rendered)', () => {
+    // Notes are private; only script-injection patterns are blocked, not all `<`
+    expect(validateUserNote('a > b is true')).toEqual([]);
+  });
+});
+
+describe('isValidField helper', () => {
+  it('narrows type correctly', () => {
+    const r = validateSpaceName('Valid Name');
+    if (isValidField(r)) {
+      // typescript should narrow r to FieldValidationOk here
+      expect(r.ok).toBe(true);
+    }
+  });
+
+  it('returns false for errors', () => {
+    expect(isValidField(validateSpaceName(''))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

New `src/validation/` module exposing 9 cross-platform field validators:

- `validateSpaceName`, `validateDisplayName`, `validateChannelName`, `validateChannelTopic`, `validateGroupName`, `validateDeviceName` — single-result validators
- `validateSpaceDescription`, `validateUserBio`, `validateUserNote` — multi-result validators (return arrays)
- `FieldValidationResult` discriminated union with `isValidField` type guard

Validators return structured `{ ok, errorKey, errorVars? }` results. The new errorKey pattern is documented in [the cross-repo workflow doc](https://github.com/QuilibriumNetwork/quorum-desktop/blob/feat/shared-validation-hooks/.agents/tasks/quorum-shared-migration/2026-05-28-cross-repo-workflow.md) section \"i18n in shared\".

## Cross-repo migration

This is part of a 2-repo change:
- **quorum-shared** (this PR): adds validators
- **quorum-desktop**: refactors `useSpaceNameValidation`, `useDisplayNameValidation`, `useChannelValidation`, `useGroupNameValidation`, `useDeviceNameValidation` to thin Lingui-translating wrappers (PR will follow once this merges)
- **quorum-mobile**: NOT touched in this batch. Mobile has duplicate `validateSpaceName` + inline length constants in `SpaceModal.tsx` / `SpaceSettingsModal.tsx`; adoption deferred (requires runtime testing). Task file dropped locally for a future mobile session.

## Why

Desktop and mobile had parallel validation implementations diverging slightly (40 vs 50 char limit, XSS check on desktop but not mobile, Lingui on desktop but hardcoded English on mobile). Mobile's `SpaceModal.tsx:38` had a comment \"matches desktop\" — explicit intent to converge. This PR provides the shared API.

## Constant changes

- `MAX_NAME_LENGTH`: 40 → 50 (aligned to mobile's existing value)
- New `MIN_NAME_LENGTH = 2` (aligned to mobile; only `validateSpaceName` enforces it — display/channel/group accept single-char names matching pre-refactor behaviour)

## Compatibility

- **Additive only.** No exports removed or renamed.
- `MAX_NAME_LENGTH` value change is breaking only for code that *asserts the specific value* — no such code exists; the constant is used as a max-length check, where a higher limit accepts more inputs (strict superset of old behaviour).
- Existing `ValidationResult` type in `src/utils/validation.ts` (used by `validateMessageContent`) is unchanged. New types are named `FieldValidationResult` to avoid collision.

## Verification

- [x] `yarn build` (CJS + ESM + native)
- [x] `yarn test` (231 passed — added 42 new validator tests, no regressions)