### PR TITLE
feat(utils): add toggleRolePermission and setRolePermissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-20",
+  "version": "2.1.0-21",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,6 +8,7 @@ export * from './formatting';
 export * from './encoding';
 export * from './logger';
 export * from './permissions';
+export * from './roleUtils';
 export * from './channelPermissions';
 export * from './channelUtils';
 export * from './messageGrouping';

--- a/src/utils/roleUtils.test.ts
+++ b/src/utils/roleUtils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { toggleRolePermission, setRolePermissions } from './roleUtils';
+import type { Role } from '../types';
+
+const baseRole: Role = {
+  roleId: 'r1',
+  displayName: 'Mod',
+  roleTag: 'mod',
+  color: 'rgb(0,0,0)',
+  members: [],
+  permissions: [],
+  isPublic: true,
+};
+
+describe('toggleRolePermission', () => {
+  it('adds the permission when absent', () => {
+    const result = toggleRolePermission(baseRole, 'message:delete');
+    expect(result.permissions).toEqual(['message:delete']);
+  });
+
+  it('removes the permission when present', () => {
+    const role: Role = { ...baseRole, permissions: ['message:delete', 'message:pin'] };
+    const result = toggleRolePermission(role, 'message:delete');
+    expect(result.permissions).toEqual(['message:pin']);
+  });
+
+  it('does not mutate the input role', () => {
+    const role: Role = { ...baseRole, permissions: ['message:delete'] };
+    const snapshot = [...role.permissions];
+    toggleRolePermission(role, 'message:pin');
+    expect(role.permissions).toEqual(snapshot);
+  });
+});
+
+describe('setRolePermissions', () => {
+  it('replaces permissions with the new list', () => {
+    const role: Role = { ...baseRole, permissions: ['message:delete'] };
+    const result = setRolePermissions(role, ['message:pin', 'user:mute']);
+    expect(result.permissions).toEqual(['message:pin', 'user:mute']);
+  });
+
+  it('clears permissions when given an empty list', () => {
+    const role: Role = { ...baseRole, permissions: ['message:delete'] };
+    const result = setRolePermissions(role, []);
+    expect(result.permissions).toEqual([]);
+  });
+
+  it('does not mutate the input role', () => {
+    const role: Role = { ...baseRole, permissions: ['message:delete'] };
+    const snapshot = [...role.permissions];
+    setRolePermissions(role, ['message:pin']);
+    expect(role.permissions).toEqual(snapshot);
+  });
+});

--- a/src/utils/roleUtils.ts
+++ b/src/utils/roleUtils.ts
@@ -1,0 +1,24 @@
+import type { Permission, Role } from '../types';
+
+/**
+ * Add or remove a permission from a role.
+ * If the role already has the permission, removes it.
+ * If not, adds it.
+ * Returns a new Role; does not mutate the input.
+ */
+export function toggleRolePermission(role: Role, permission: Permission): Role {
+  return {
+    ...role,
+    permissions: role.permissions.includes(permission)
+      ? role.permissions.filter((p) => p !== permission)
+      : [...role.permissions, permission],
+  };
+}
+
+/**
+ * Replace a role's permissions with a new list.
+ * Returns a new Role; does not mutate the input.
+ */
+export function setRolePermissions(role: Role, permissions: Permission[]): Role {
+  return { ...role, permissions };
+}


### PR DESCRIPTION
## What
Extract two pure role-mutation helpers (`toggleRolePermission`, `setRolePermissions`) inlined byte-for-byte in both quorum-desktop and quorum-mobile today. Additive — no breaking changes.

## Cross-repo migration
This is part of a multi-repo change:
- **quorum-shared**: THIS PR (publishes 2.1.0-21)
- **quorum-desktop**: opening immediately after merge
- **quorum-mobile**: task dropped — see mobile-tasks-pending.md

## Why
Both platforms inline the same include/filter/spread pattern in their role-management code (desktop `useRoleManagement`, mobile `useToggleRolePermission` + `useUpdateRole`). Promoting these two pure functions eliminates the duplication once, and any future role-mutation hook reaches for the shared util by default.

Scope-limited per the Phase 2 verification (see `2026-05-29-migrate-role-mutation-helpers.md`):
- ✅ `toggleRolePermission(role, permission): Role`
- ✅ `setRolePermissions(role, permissions): Role`
- ❌ UUID gen — Trap E (Web Crypto vs polyfill, platform-correct divergence)
- ❌ `toggleRolePublic` — tiny semantic divergence (`=== false` vs `?? false`)
- ❌ Per-field setters — too thin (1-2 LOC)
- ❌ Member assignment — desktop doesn't have it

## Version coordination note
Master is currently at `2.1.0-20` (the recent merge resolved the version conflict with the upstream `2.1.0-17` Farcaster commit in favor of the higher number). This PR continues the sequence to `2.1.0-21`.

## Verification
- [x] `yarn tsc --noEmit` passes
- [x] `yarn test src/utils/roleUtils.test.ts` — 6/6 pass
- [x] `yarn build` produces clean output; `toggleRolePermission` + `setRolePermissions` visible in `dist/utils/roleUtils.d.ts`