### PR TITLE
feat(icon): add grip-vertical (IconGripVertical)

### DIFF
--- a/src/primitives/Icon/iconMapping.ts
+++ b/src/primitives/Icon/iconMapping.ts
@@ -49,6 +49,7 @@ export const iconComponentMap: Record<IconName, string> = {
   menu: 'IconMenu2',
   dots: 'IconDots',
   'dots-vertical': 'IconDotsVertical',
+  'grip-vertical': 'IconGripVertical',
   refresh: 'IconRefresh',
   'external-link': 'IconExternalLink',
   filter: 'IconFilter',

--- a/src/primitives/Icon/types.ts
+++ b/src/primitives/Icon/types.ts
@@ -39,6 +39,7 @@ export type IconName =
   | 'menu'
   | 'dots'
   | 'dots-vertical'
+  | 'grip-vertical'
   | 'refresh'
   | 'external-link'
   | 'filter'


### PR DESCRIPTION
Adds `grip-vertical` to the shared Icon component, mapped to Tabler's `IconGripVertical`. Used by the new desktop Channels tab drag-and-drop handles.