### PR TITLE
fix(modal): close button only dismisses its own modal

### DIFF
--- a/src/primitives/Modal/Modal.web.tsx
+++ b/src/primitives/Modal/Modal.web.tsx
@@ -1,7 +1,71 @@
-import React, { useId } from 'react';
+import React, { useContext, useId } from 'react';
 import { WebModalProps } from './types';
 import { ModalContainer } from './ModalContainer';
+import { ModalCloseContext } from './ModalContainer/ModalContainer.web';
 import { Icon } from '../Icon';
+
+const ModalInner: React.FC<{
+  title?: React.ReactNode;
+  modalTitleId: string;
+  size: 'small' | 'medium' | 'large';
+  noPadding: boolean;
+  className: string;
+  hideClose: boolean;
+  titleAlign: 'left' | 'center';
+  children: React.ReactNode;
+}> = ({
+  title,
+  modalTitleId,
+  size,
+  noPadding,
+  className,
+  hideClose,
+  titleAlign,
+  children,
+}) => {
+  const close = useContext(ModalCloseContext);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? modalTitleId : undefined}
+      className={`quorum-modal text-subtle relative pointer-events-auto quorum-modal-${size} ${noPadding ? 'quorum-modal-no-padding' : ''} ${className}`}
+    >
+      {!hideClose && (
+        <button
+          type="button"
+          aria-label="Close dialog"
+          className="quorum-modal-close select-none cursor-pointer"
+          onClick={(e) => {
+            e.stopPropagation();
+            // Trigger this modal's animated close. Falls back to dispatching
+            // an Escape event only if no context is present (legacy fallback).
+            if (close) {
+              close();
+            } else {
+              const escEvent = new KeyboardEvent('keydown', { key: 'Escape' });
+              document.dispatchEvent(escEvent);
+            }
+          }}
+        >
+          <Icon name="close" size="md" />
+        </button>
+      )}
+
+      {title && (
+        <div
+          id={modalTitleId}
+          className={`quorum-modal-title select-none cursor-default ${titleAlign === 'center' ? 'quorum-modal-title-center' : ''}`}
+        >
+          {title}
+        </div>
+      )}
+
+      <div className="quorum-modal-container">{children}</div>
+    </div>
+  );
+};
 
 const Modal: React.FC<WebModalProps> = ({
   title,
@@ -26,39 +90,17 @@ const Modal: React.FC<WebModalProps> = ({
       closeOnEscape={closeOnEscape}
       animationDuration={300}
     >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={title ? modalTitleId : undefined}
-        className={`quorum-modal text-subtle relative pointer-events-auto quorum-modal-${size} ${noPadding ? 'quorum-modal-no-padding' : ''} ${className}`}
+      <ModalInner
+        title={title}
+        modalTitleId={modalTitleId}
+        size={size}
+        noPadding={noPadding}
+        className={className}
+        hideClose={hideClose}
+        titleAlign={titleAlign}
       >
-        {!hideClose && (
-          <button
-            type="button"
-            aria-label="Close dialog"
-            className="quorum-modal-close select-none cursor-pointer"
-            onClick={(e) => {
-              e.stopPropagation();
-              // Trigger ESC key event to use ModalContainer's animation
-              const escEvent = new KeyboardEvent('keydown', { key: 'Escape' });
-              document.dispatchEvent(escEvent);
-            }}
-          >
-            <Icon name="close" size="md" />
-          </button>
-        )}
-
-        {title && (
-          <div
-            id={modalTitleId}
-            className={`quorum-modal-title select-none cursor-default ${titleAlign === 'center' ? 'quorum-modal-title-center' : ''}`}
-          >
-            {title}
-          </div>
-        )}
-
-        <div className="quorum-modal-container">{children}</div>
-      </div>
+        {children}
+      </ModalInner>
     </ModalContainer>
   );
 };

--- a/src/primitives/Modal/ModalContainer/ModalContainer.web.tsx
+++ b/src/primitives/Modal/ModalContainer/ModalContainer.web.tsx
@@ -1,10 +1,17 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, createContext } from 'react';
 import clsx from 'clsx';
 import { ModalContainerProps } from './types';
 import { OverlayBackdrop } from '../../OverlayBackdrop';
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Context exposing the current modal's animated close handler.
+ * Used by the close button in Modal so it can dismiss this specific modal
+ * (with animation) without affecting other open modals.
+ */
+export const ModalCloseContext = createContext<(() => void) | null>(null);
 
 export const ModalContainer: React.FC<ModalContainerProps> = ({
   visible,
@@ -127,34 +134,38 @@ export const ModalContainer: React.FC<ModalContainerProps> = ({
 
   if (!showBackdrop) {
     return (
-      <div
-        ref={containerRef}
-        className={contentClasses}
-        style={{ animationDuration: `${animationDuration}ms` }}
-        onKeyDown={handleKeyDown}
-      >
-        {children}
-      </div>
+      <ModalCloseContext.Provider value={handleClose}>
+        <div
+          ref={containerRef}
+          className={contentClasses}
+          style={{ animationDuration: `${animationDuration}ms` }}
+          onKeyDown={handleKeyDown}
+        >
+          {children}
+        </div>
+      </ModalCloseContext.Provider>
     );
   }
 
   return (
-    <OverlayBackdrop
-      visible={true}
-      onBackdropClick={handleBackdropClick}
-      zIndex={zIndex}
-      blur={backdropBlur}
-      closeOnBackdropClick={closeOnBackdropClick}
-    >
-      <div
-        ref={containerRef}
-        className={contentClasses}
-        onClick={(e) => e.stopPropagation()}
-        style={{ animationDuration: `${animationDuration}ms` }}
-        onKeyDown={handleKeyDown}
+    <ModalCloseContext.Provider value={handleClose}>
+      <OverlayBackdrop
+        visible={true}
+        onBackdropClick={handleBackdropClick}
+        zIndex={zIndex}
+        blur={backdropBlur}
+        closeOnBackdropClick={closeOnBackdropClick}
       >
-        {children}
-      </div>
-    </OverlayBackdrop>
+        <div
+          ref={containerRef}
+          className={contentClasses}
+          onClick={(e) => e.stopPropagation()}
+          style={{ animationDuration: `${animationDuration}ms` }}
+          onKeyDown={handleKeyDown}
+        >
+          {children}
+        </div>
+      </OverlayBackdrop>
+    </ModalCloseContext.Provider>
   );
 };


### PR DESCRIPTION
## Problem

The close (X) button in the Modal primitive dispatched a synthetic Escape keydown on `document`. Because every open Modal listens for Escape at the document level, clicking the X on a nested modal closed every other open modal too.

Reproduced in quorum-desktop: opening the channel/group editor from inside Space Settings → clicking X on the editor closed Space Settings as well.

## Fix

`ModalContainer` now exposes its `handleClose` via a new `ModalCloseContext`. The X button reads it and calls it directly — only this modal's close animation runs. Falls back to the previous Escape-dispatch when no context is present (defensive, shouldn't hit in practice).

## Tested locally

- Nested modal close → only the inner modal closes
- Standalone modals close normally with animation
- Escape key still closes
- Backdrop click still closes where enabled