### PR TITLE
chore(types): remove Channel.isPinned and Channel.pinnedAt

### DIFF
--- a/src/types/space.ts
+++ b/src/types/space.ts
@@ -55,8 +55,6 @@ export type Channel = {
   mentions?: string;
   isReadOnly?: boolean;
   managerRoleIds?: string[];
-  isPinned?: boolean;
-  pinnedAt?: number;
   icon?: string;
   iconColor?: string;
   iconVariant?: 'outline' | 'filled';


### PR DESCRIPTION
## Summary

Removes the now-unused \`isPinned\` and \`pinnedAt\` fields from the \`Channel\` type. These backed the channel-pinning feature that has been dropped on desktop in favour of drag-and-drop channel ordering.

The only consumer in any repo was mobile's \`usePinChannel\` mutation, which was removed in [quorum-mobile#68](https://github.com/QuilibriumNetwork/quorum-mobile/pull/68). No reads remain in either repo.

## Important: not the same as message pinning

\`Message.isPinned\` / \`pinnedAt\` (separate fields on a separate type, used by \`usePinnedMessages\` etc.) are completely unaffected.

## Test plan
- [x] grep \`Channel.*isPinned\` / \`channel.isPinned\` / \`channel.pinnedAt\` across \`src/\` → 0 hits after change
- [x] \`yarn build\` succeeds