### PR TITLE
feat(icon): add 7 Tabler icons and custom-SVG support with Farcaster

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-dom": ">=19.0.0",
     "react-dropzone": ">=14.0.0",
     "react-native": ">=0.81.0",
+    "react-native-svg": ">=15.0.0",
     "react-tooltip": ">=5.0.0"
   },
   "peerDependenciesMeta": {
@@ -90,14 +91,17 @@
     "react-native": {
       "optional": true
     },
+    "react-native-svg": {
+      "optional": true
+    },
     "react-tooltip": {
       "optional": true
     }
   },
   "devDependencies": {
-    "@noble/curves": "2.0.1",
     "@gorhom/bottom-sheet": "5.2.8",
     "@lingui/core": "4.14.1",
+    "@noble/curves": "2.0.1",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@tabler/icons-react": "3.40.0",
     "@tabler/icons-react-native": "3.40.0",
@@ -116,6 +120,7 @@
     "react-dropzone": "14.4.1",
     "react-native": "0.81.5",
     "react-native-safe-area-context": "5.7.0",
+    "react-native-svg": "15.12.1",
     "react-tooltip": "5.30.0",
     "tsup": "8.5.1",
     "typescript": "5.9.3",

--- a/src/primitives/Icon/Icon.native.tsx
+++ b/src/primitives/Icon/Icon.native.tsx
@@ -1,9 +1,11 @@
 import { logger } from '../../utils';
 import React from 'react';
 import { TouchableOpacity } from 'react-native';
+import Svg, { Path } from 'react-native-svg';
 import * as IconLibrary from '@tabler/icons-react-native';
 import { IconNativeProps, IconSize } from './types';
 import { iconComponentMap } from './iconMapping';
+import { customIcons, isCustomIcon } from './customIcons';
 import { useTheme } from '../theme';
 
 // Convert semantic size to pixel size (same as web)
@@ -44,6 +46,38 @@ export function Icon({
   if (!iconComponentName) {
     logger.warn(`Icon "${name}" not found in icon mapping`);
     return null;
+  }
+
+  if (isCustomIcon(name)) {
+    const def = customIcons[name];
+    const iconSize = getSizeValue(size);
+    const iconColor = color || colors.text.main;
+    const combinedStyle = {
+      ...(disabled && { opacity: 0.5 }),
+      ...style,
+    };
+
+    const svg = (
+      <Svg
+        width={iconSize}
+        height={iconSize}
+        viewBox={def.viewBox}
+        style={combinedStyle}
+      >
+        {def.paths.map((p, i) => (
+          <Path key={i} d={p.d} fill={iconColor} fillRule={p.fillRule} />
+        ))}
+      </Svg>
+    );
+
+    if (onClick && !disabled) {
+      return (
+        <TouchableOpacity onPress={onClick} activeOpacity={0.7}>
+          {svg}
+        </TouchableOpacity>
+      );
+    }
+    return svg;
   }
 
   // Determine final component name based on variant

--- a/src/primitives/Icon/Icon.web.tsx
+++ b/src/primitives/Icon/Icon.web.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import * as IconLibrary from '@tabler/icons-react';
 import { IconWebProps, IconSize } from './types';
 import { iconComponentMap } from './iconMapping';
+import { customIcons, isCustomIcon } from './customIcons';
 
 // Convert semantic size to pixel size
 const getSizeValue = (size: IconSize): number => {
@@ -39,6 +40,10 @@ export function Icon({
   if (!iconComponentName) {
     logger.warn(`Icon "${name}" not found in icon mapping`);
     return null;
+  }
+
+  if (isCustomIcon(name)) {
+    return renderCustomIcon();
   }
 
   // Allow global flag to override variant for quick testing (development only)
@@ -107,6 +112,39 @@ export function Icon({
         id={id}
         onClick={onClick}
       />
+    );
+  }
+
+  function renderCustomIcon() {
+    const def = customIcons[name];
+    const iconSize = getSizeValue(size);
+    let iconColor = (style && style.color) || color || 'currentColor';
+    if (iconColor === 'inherit') iconColor = 'currentColor';
+
+    const combinedStyle = {
+      ...(disabled && { opacity: 0.5 }),
+      ...(onClick && { cursor: 'pointer' }),
+      ...style,
+      color: iconColor,
+    };
+
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox={def.viewBox}
+        width={iconSize}
+        height={iconSize}
+        fill="currentColor"
+        className={className}
+        style={combinedStyle}
+        id={id}
+        onClick={onClick}
+        aria-hidden="true"
+      >
+        {def.paths.map((p, i) => (
+          <path key={i} d={p.d} fill={p.fill} fillRule={p.fillRule} />
+        ))}
+      </svg>
     );
   }
 }

--- a/src/primitives/Icon/customIcons.ts
+++ b/src/primitives/Icon/customIcons.ts
@@ -1,0 +1,33 @@
+/**
+ * Custom SVG icons not available in the Tabler library.
+ *
+ * Each entry defines the SVG path data plus the viewBox it was authored against.
+ * Icon.web renders these as inline <svg>; Icon.native renders them via
+ * react-native-svg.
+ *
+ * To add a new custom icon:
+ *   1. Add a key here with viewBox + path data
+ *   2. Add the same key to IconName in types.ts
+ *   3. Add the key in iconMapping.ts with value '__custom__'
+ */
+
+export interface CustomIconDef {
+  viewBox: string;
+  paths: Array<{ d: string; fill?: string; fillRule?: 'nonzero' | 'evenodd' }>;
+}
+
+export const customIcons: Record<string, CustomIconDef> = {
+  farcaster: {
+    viewBox: '0 0 32 32',
+    paths: [
+      {
+        d: 'M5.507 0.072L26.097 0.072L26.097 4.167L31.952 4.167L30.725 8.263L29.686 8.263L29.686 24.833C30.207 24.833 30.63 25.249 30.63 25.763L30.63 26.88L30.819 26.88C31.341 26.88 31.764 27.297 31.764 27.811L31.764 28.928L21.185 28.928L21.185 27.811C21.185 27.297 21.608 26.88 22.13 26.88L22.319 26.88L22.319 25.763C22.319 25.316 22.639 24.943 23.065 24.853L23.045 15.71C22.711 12.057 19.596 9.194 15.802 9.194C12.008 9.194 8.893 12.057 8.559 15.71L8.539 24.845C9.043 24.919 9.663 25.302 9.663 25.763L9.663 26.88L9.852 26.88C10.373 26.88 10.796 27.297 10.796 27.811L10.796 28.928L0.218 28.928L0.218 27.811C0.218 27.297 0.641 26.88 1.162 26.88L1.351 26.88L1.351 25.763C1.351 25.249 1.774 24.833 2.296 24.833L2.296 8.263L1.257 8.263L0.029 4.167L5.507 4.167L5.507 0.072Z',
+        fill: 'currentColor',
+      },
+    ],
+  },
+};
+
+export function isCustomIcon(name: string): boolean {
+  return name in customIcons;
+}

--- a/src/primitives/Icon/iconMapping.ts
+++ b/src/primitives/Icon/iconMapping.ts
@@ -51,9 +51,13 @@ export const iconComponentMap: Record<IconName, string> = {
   'dots-vertical': 'IconDotsVertical',
   'grip-vertical': 'IconGripVertical',
   refresh: 'IconRefresh',
+  repeat: 'IconRepeat',
   'external-link': 'IconExternalLink',
   filter: 'IconFilter',
   sort: 'IconArrowsSort',
+  'layout-grid-add': 'IconLayoutGridAdd',
+  'grid-dots': 'IconGridDots',
+  'list-search': 'IconListSearch',
 
   // Actions
   reply: 'IconArrowBackUp',
@@ -85,6 +89,8 @@ export const iconComponentMap: Record<IconName, string> = {
   'user-x': 'IconUserX',
   'user-minus': 'IconUserMinus',
   'user-question': 'IconUserQuestion',
+  'user-search': 'IconUserSearch',
+  'message-search': 'IconMessageCircleSearch',
   party: 'IconConfetti',
   gift: 'IconGift',
   'hand-peace': 'IconHandStop',
@@ -95,6 +101,7 @@ export const iconComponentMap: Record<IconName, string> = {
   smile: 'IconMoodSmile',
   'mood-happy': 'IconMoodHappy',
   heart: 'IconHeart',
+  'heart-off': 'IconHeartOff',
   star: 'IconStar',
   'star-off': 'IconStarOff',
   eye: 'IconEye',
@@ -181,7 +188,12 @@ export const iconComponentMap: Record<IconName, string> = {
   ai: 'IconAi',
   fire: 'IconFlame',
   globe: 'IconWorld',
+  'globe-search': 'IconWorldSearch',
   plane: 'IconPlane',
+
+  // Custom SVG icons — handled separately in Icon.web/native, not via Tabler library.
+  // Entry kept here so isValidIconName() recognises the name.
+  farcaster: '__custom__',
 };
 
 /**

--- a/src/primitives/Icon/types.ts
+++ b/src/primitives/Icon/types.ts
@@ -41,9 +41,13 @@ export type IconName =
   | 'dots-vertical'
   | 'grip-vertical'
   | 'refresh'
+  | 'repeat'
   | 'external-link'
   | 'filter'
   | 'sort'
+  | 'layout-grid-add'
+  | 'grid-dots'
+  | 'list-search'
 
   // Actions
   | 'reply'
@@ -75,6 +79,8 @@ export type IconName =
   | 'user-x'
   | 'user-minus'
   | 'user-question'
+  | 'user-search'
+  | 'message-search'
   | 'party'
   | 'gift'
   | 'hand-peace'
@@ -85,6 +91,7 @@ export type IconName =
   | 'smile'
   | 'mood-happy'
   | 'heart'
+  | 'heart-off'
   | 'star'
   | 'star-off'
   | 'eye'
@@ -172,7 +179,11 @@ export type IconName =
   | 'ai'
   | 'fire'
   | 'globe'
-  | 'plane';
+  | 'globe-search'
+  | 'plane'
+
+  // Custom SVG icons
+  | 'farcaster';
 
 export type IconSize =
   | 'xs'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1441,6 +1441,11 @@ bidi-js@^1.0.3:
   dependencies:
     require-from-string "^2.0.2"
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 brace-expansion@^1.1.7:
   version "1.1.12"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz"
@@ -1644,6 +1649,25 @@ convert-source-map@^2.0.0:
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+css-select@^5.1.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.2.2.tgz#01b6e8d163637bb2dd6c982ca4ed65863682786e"
+  integrity sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-tree@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
+  integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
+  dependencies:
+    mdn-data "2.0.14"
+    source-map "^0.6.1"
+
 css-tree@^3.0.0, css-tree@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz"
@@ -1651,6 +1675,11 @@ css-tree@^3.0.0, css-tree@^3.2.1:
   dependencies:
     mdn-data "2.27.1"
     source-map-js "^1.2.1"
+
+css-what@^6.1.0:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.2.2.tgz#cdcc8f9b6977719fdfbd1de7aec24abf756b9dea"
+  integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
 
 csstype@^3.2.2:
   version "3.2.3"
@@ -1723,6 +1752,36 @@ devlop@^1.0.0, devlop@^1.1.0:
   dependencies:
     dequal "^2.0.0"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
@@ -1747,6 +1806,11 @@ encodeurl@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 entities@^8.0.0:
   version "8.0.0"
@@ -2621,6 +2685,11 @@ mdast-util-to-string@^4.0.0:
   dependencies:
     "@types/mdast" "^4.0.0"
 
+mdn-data@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
+  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
+
 mdn-data@2.27.1:
   version "2.27.1"
   resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz"
@@ -3209,6 +3278,13 @@ normalize-path@^3.0.0:
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
+
 nullthrows@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz"
@@ -3431,6 +3507,15 @@ react-native-safe-area-context@5.7.0:
   version "5.7.0"
   resolved "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.7.0.tgz"
   integrity sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ==
+
+react-native-svg@15.12.1:
+  version "15.12.1"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.12.1.tgz#7ba756dd6a235f86a2c312a1e7911f9b0d18ad3a"
+  integrity sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==
+  dependencies:
+    css-select "^5.1.0"
+    css-tree "^1.1.3"
+    warn-once "0.1.1"
 
 react-native@0.81.5:
   version "0.81.5"
@@ -3707,7 +3792,7 @@ source-map@^0.5.6:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
   integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
 
-source-map@^0.6.0:
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -4139,6 +4224,11 @@ walker@^1.0.7, walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+warn-once@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/warn-once/-/warn-once-0.1.1.tgz#952088f4fb56896e73fd4e6a3767272a3fccce43"
+  integrity sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==
 
 webidl-conversions@^8.0.1:
   version "8.0.1"


### PR DESCRIPTION
## Summary

- Adds 7 new Tabler icons: `layout-grid-add`, `grid-dots`, `globe-search`, `user-search`, `message-search`, `list-search`, `repeat`, `heart-off`. (`IconWorld`, `IconAt`, `IconHeart` were already mapped as `globe`/`at`/`heart` and skipped.)
- Introduces a `customIcons` registry so non-Tabler SVGs can ride through the same `<Icon name="..." />` API on both web and native. First entry: `farcaster`.
- Adds `react-native-svg` as an optional peer dep (already present in quorum-mobile) so native consumers can render the custom paths.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn build` passes (both web and native bundles)
- [ ] Visual smoke test in quorum-desktop after consuming