### PR TITLE
feat(types): DirectoryEntry + UserConfig.hideMutedSpacesFromSidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-21",
+  "version": "2.1.0-22",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/types/directory.ts
+++ b/src/types/directory.ts
@@ -1,0 +1,35 @@
+/**
+ * Public space directory types.
+ *
+ * Wire shapes returned by GET /directory. Used by both desktop and mobile
+ * to render the "Discover Spaces" surface — a curated/server-side list of
+ * public spaces a user can browse and join without a private invite link.
+ */
+
+export type SpaceCategory =
+  | 'community'
+  | 'gaming'
+  | 'tech'
+  | 'crypto'
+  | 'social'
+  | 'education'
+  | 'other';
+
+export interface DirectoryEntry {
+  space_address: string;
+  name: string;
+  description: string;
+  icon: string;
+  invite_link: string;
+  category: string;
+  status: string;
+  submitted_at: number;
+  reviewed_at?: number;
+  member_count?: number;
+}
+
+export interface DirectoryResponse {
+  entries: DirectoryEntry[];
+  total: number;
+  has_more: boolean;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -93,3 +93,10 @@ export type {
 // Typing types (ephemeral typing-indicator protocol)
 export type { TypingMessageType, TypingMessage, TypingScope } from './typing';
 export { scopeKey, scopeFromMessage } from './typing';
+
+// Directory types (public space discovery)
+export type {
+  SpaceCategory,
+  DirectoryEntry,
+  DirectoryResponse,
+} from './directory';

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -85,6 +85,7 @@ export type UserConfig = {
     [spaceId: string]: string[];
   };
   showMutedChannels?: boolean;
+  hideMutedSpacesFromSidebar?: boolean;
   favoriteDMs?: string[];
   mutedConversations?: string[];
   spaceTagId?: string;


### PR DESCRIPTION
## What
Add additive type exports for the upcoming desktop unified `/spaces` page:

- `DirectoryEntry`, `DirectoryResponse`, `SpaceCategory` — wire shapes for the `/directory` server endpoint
- `UserConfig.hideMutedSpacesFromSidebar?: boolean` — new optional UI preference field, mirrors the existing `showMutedChannels?: boolean` pattern

## Cross-repo migration
- **quorum-shared**: THIS PR (version 2.1.0-22)
- **quorum-desktop**: consuming branch `feat/port-discover-spaces` (PR opened after this merges)
- **quorum-mobile**: task drop logged — mobile's local `DirectoryEntry`/`DirectoryResponse` in `services/api/quorumClient.ts:67-84` can swap to shared types whenever convenient. Mobile keeps working unchanged on the old version.

## Why
Desktop is shipping a public space directory ("Discover Spaces"). The wire types are identical to mobile's local definitions, so they belong in shared. Additive: zero breaking change to mobile.

## Why this is safe to merge whenever
Purely additive exports + a new optional field. No consumers in shared or mobile change behavior. Desktop will consume on its own schedule.

## Verification
- [x] `yarn build` succeeds
- [x] New types present in `dist/types/`