### PR TITLE
feat(icons): add crown icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-22",
+  "version": "2.1.0-23",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/primitives/Icon/iconMapping.ts
+++ b/src/primitives/Icon/iconMapping.ts
@@ -114,6 +114,7 @@ export const iconComponentMap: Record<IconName, string> = {
   settings: 'IconSettings',
   shield: 'IconShield',
   'shield-check': 'IconShieldCheck',
+  crown: 'IconCrown',
   key: 'IconKey',
   lock: 'IconLock',
   unlock: 'IconLockOpen',

--- a/src/primitives/Icon/types.ts
+++ b/src/primitives/Icon/types.ts
@@ -106,6 +106,7 @@ export type IconName =
   | 'settings'
   | 'shield'
   | 'shield-check'
+  | 'crown'
   | 'lock'
   | 'unlock'
   | 'login'


### PR DESCRIPTION
## What
Adds `'crown'` to the `IconName` union and maps it to Tabler's `IconCrown`. Bumps shared to `2.1.0-23`.

## Why
Desktop's new `/spaces` page uses a crown badge on owned spaces in the My Servers grid. The current substitute is `shield-check`, which reads as "verified" rather than "owner".

## Cross-repo migration
- **quorum-shared**: THIS PR (2.1.0-23)
- **quorum-desktop**: branch `feat/port-discover-spaces` swaps `shield-check` → `crown` once this merges
- **quorum-mobile**: no action needed (additive)

## Verification
- [x] `yarn build` succeeds
- [x] `IconCrown` exists in `@tabler/icons-react` (default Tabler export)