### PR TITLE
feat(types): optional senderIcon on Bookmark.cachedPreview

### DIFF
--- a/src/primitives/Icon/iconMapping.ts
+++ b/src/primitives/Icon/iconMapping.ts
@@ -85,6 +85,7 @@ export const iconComponentMap: Record<IconName, string> = {
   messages: 'IconMessages',
   user: 'IconUser',
   users: 'IconUsers',
+  'users-group': 'IconUsersGroup',
   'user-plus': 'IconUserPlus',
   'user-x': 'IconUserX',
   'user-minus': 'IconUserMinus',
@@ -190,6 +191,7 @@ export const iconComponentMap: Record<IconName, string> = {
   fire: 'IconFlame',
   globe: 'IconWorld',
   'globe-search': 'IconWorldSearch',
+  compass: 'IconCompass',
   plane: 'IconPlane',
 
   // Custom SVG icons — handled separately in Icon.web/native, not via Tabler library.

--- a/src/primitives/Icon/iconMapping.ts
+++ b/src/primitives/Icon/iconMapping.ts
@@ -55,6 +55,7 @@ export const iconComponentMap: Record<IconName, string> = {
   'external-link': 'IconExternalLink',
   filter: 'IconFilter',
   sort: 'IconArrowsSort',
+  'layout-grid': 'IconLayoutGrid',
   'layout-grid-add': 'IconLayoutGridAdd',
   'grid-dots': 'IconGridDots',
   'list-search': 'IconListSearch',

--- a/src/primitives/Icon/types.ts
+++ b/src/primitives/Icon/types.ts
@@ -45,6 +45,7 @@ export type IconName =
   | 'external-link'
   | 'filter'
   | 'sort'
+  | 'layout-grid'
   | 'layout-grid-add'
   | 'grid-dots'
   | 'list-search'

--- a/src/primitives/Icon/types.ts
+++ b/src/primitives/Icon/types.ts
@@ -75,6 +75,7 @@ export type IconName =
   | 'messages'
   | 'user'
   | 'users'
+  | 'users-group'
   | 'user-plus'
   | 'user-x'
   | 'user-minus'
@@ -181,6 +182,7 @@ export type IconName =
   | 'fire'
   | 'globe'
   | 'globe-search'
+  | 'compass'
   | 'plane'
 
   // Custom SVG icons

--- a/src/primitives/Select/Select.web.tsx
+++ b/src/primitives/Select/Select.web.tsx
@@ -17,6 +17,7 @@ const Select: React.FC<WebSelectProps> = ({
   style,
   size = 'medium',
   variant = 'filled',
+  borderedDropdown = false,
   fullWidth = false,
   width,
   dropdownPlacement = 'auto',
@@ -374,7 +375,7 @@ const Select: React.FC<WebSelectProps> = ({
           <Portal>
             <div
               ref={dropdownRef}
-              className={`quorum-select__dropdown quorum-select__dropdown--fixed${dropdownClassName ? ` ${dropdownClassName}` : ''}`}
+              className={`quorum-select__dropdown quorum-select__dropdown--fixed${borderedDropdown ? ' quorum-select__dropdown--bordered' : ''}${dropdownClassName ? ` ${dropdownClassName}` : ''}`}
               role="listbox"
               style={dropdownStyle}
               aria-label={placeholder}

--- a/src/primitives/Select/types.ts
+++ b/src/primitives/Select/types.ts
@@ -1,11 +1,15 @@
 export interface SelectOption {
   value: string;
   label: string;
-  icon?: string; // Temporary: emoji or Unicode character, will be FontAwesome icon name later
-  avatar?: string; // URL for user avatars (for conversation dropdowns)
-  displayName?: string; // Display name for user initials fallback (when avatar is invalid)
-  userAddress?: string; // User address for deterministic color generation in initials
-  subtitle?: string; // Secondary text (like user addresses)
+  /** Emoji or Unicode for now; will become an icon name later. */
+  icon?: string;
+  /** URL; falls back to initials when invalid via `isAvatarValid`. */
+  avatar?: string;
+  /** Used for initials fallback when avatar is missing/invalid. */
+  displayName?: string;
+  /** Drives deterministic color generation for the initials fallback. */
+  userAddress?: string;
+  subtitle?: string;
   disabled?: boolean;
 }
 
@@ -15,10 +19,12 @@ export interface SelectOptionGroup {
 }
 
 export interface BaseSelectProps {
-  value?: string | string[]; // Support both single and multiple values
-  options?: SelectOption[]; // Simple options (alternative to groups)
-  groups?: SelectOptionGroup[]; // Grouped options (alternative to options)
-  onChange?: (value: string | string[]) => void; // Handle both single and multiple values
+  /** Single string in single-select, string[] in multiple mode. */
+  value?: string | string[];
+  /** Use either `options` or `groups`, not both. */
+  options?: SelectOption[];
+  groups?: SelectOptionGroup[];
+  onChange?: (value: string | string[]) => void;
   placeholder?: string;
   disabled?: boolean;
   error?: boolean;
@@ -26,44 +32,50 @@ export interface BaseSelectProps {
   className?: string;
   style?: React.CSSProperties;
   size?: 'small' | 'medium' | 'large';
+  /** Trigger style. Dropdown border is controlled separately by `borderedDropdown`. */
   variant?: 'filled' | 'bordered';
+  /** When true, the dropdown panel gets a visible border. */
+  borderedDropdown?: boolean;
   fullWidth?: boolean;
-  width?: string | number; // Custom width (CSS value for web, number for RN)
+  /** CSS value on web, number on native. */
+  width?: string | number;
 
-  // Avatar rendering customization (injected by consuming app)
   /** Render a custom avatar for an option. Receives the option and a size hint. */
   renderAvatar?: (option: SelectOption, size: number) => React.ReactNode;
-  /** Check if an avatar URL is valid/usable (e.g., not a placeholder). Defaults to truthy check on avatar. */
+  /** Defaults to a truthy check on `option.avatar`. */
   isAvatarValid?: (avatarUrl: string) => boolean;
 
-  // Multiselect specific props
-  multiple?: boolean; // Enable multiselect mode
+  multiple?: boolean;
+  /** Custom rendering for the selected chip(s) in multiple mode. */
   renderSelectedValue?: (
     selected: string[],
     options: SelectOption[]
-  ) => React.ReactNode; // Custom display for selected values
-  selectAllLabel?: string; // Label for "Select All" option (default: "Select All")
-  clearAllLabel?: string; // Label for "Clear All" option (default: "Clear All")
-  maxHeight?: string | number; // Maximum height for dropdown
-  showSelectAllOption?: boolean; // Show select all/clear all options (default: true when multiple)
-  maxDisplayedChips?: number; // Maximum number of chips to display before showing count (default: 3)
+  ) => React.ReactNode;
+  selectAllLabel?: string;
+  clearAllLabel?: string;
+  maxHeight?: string | number;
+  /** Defaults to true when `multiple`. */
+  showSelectAllOption?: boolean;
+  /** Selected chips beyond this count collapse into a "+N" badge. */
+  maxDisplayedChips?: number;
 
-  // Compact mode props
-  compactMode?: boolean; // Show only icon button, hide selected values
-  compactIcon?: string; // Icon to display in compact mode (default: 'filter')
-  showSelectionCount?: boolean; // Show badge with selection count in compact mode (default: false)
+  /** Hides the selected value and shows only the icon button. */
+  compactMode?: boolean;
+  /** Defaults to 'filter'. */
+  compactIcon?: string;
+  /** Compact-mode badge with the selection count. */
+  showSelectionCount?: boolean;
 }
 
 export interface WebSelectProps extends BaseSelectProps {
-  // Web-specific props
   name?: string;
   id?: string;
   autoFocus?: boolean;
-  dropdownPlacement?: 'top' | 'bottom' | 'auto'; // Dropdown positioning
-  dropdownClassName?: string; // Extra CSS class(es) for the portal dropdown
+  dropdownPlacement?: 'top' | 'bottom' | 'auto';
+  /** Extra class(es) applied to the portaled dropdown panel. */
+  dropdownClassName?: string;
 }
 
 export interface NativeSelectProps extends BaseSelectProps {
-  // Native-specific props
   testID?: string;
 }

--- a/src/types/bookmark.ts
+++ b/src/types/bookmark.ts
@@ -14,6 +14,7 @@ export type Bookmark = {
   cachedPreview: {
     senderAddress: string;
     senderName: string;
+    senderIcon?: string;
     textSnippet: string;
     messageDate: number;
     sourceName: string;


### PR DESCRIPTION
## Summary
- Adds optional `senderIcon?: string` to `Bookmark.cachedPreview` so consumers can capture the sender's avatar URL at bookmark time.
- Lets the bookmarks UI render the real avatar instead of the colored letter-tile fallback for any bookmark created after this lands.
- Backwards compatible: the field is optional. Bookmarks created before this change still parse and render with the existing default-avatar fallback.

## Consumer change (quorum-desktop)
A companion change on `feat/new-UI` updates `useBookmarks` / `useMessageActions` to read `userIcon` from the sender lookup and write it into `cachedPreview.senderIcon`, and `BookmarkCard` reads it on render. No behaviour change for existing bookmarks.

## Test plan
- [x] Type compiles
- [x] Verified end-to-end in quorum-desktop: new bookmarks render with the real sender avatar; old bookmarks keep the letter-tile fallback.