### PR TITLE
feat(types): optional threadName on Bookmark.cachedPreview

### DIFF
--- a/src/types/bookmark.ts
+++ b/src/types/bookmark.ts
@@ -15,6 +15,7 @@ export type Bookmark = {
     senderAddress: string;
     senderName: string;
     senderIcon?: string;
+    threadName?: string;
     textSnippet: string;
     messageDate: number;
     sourceName: string;


### PR DESCRIPTION
## Summary
- Adds optional `threadName?: string` to `Bookmark.cachedPreview`.
- Lets the bookmarks UI render a thread breadcrumb (`Space > #channel › Thread name`) without a per-render lookup.
- Backwards compatible: bookmarks created before this lands have no `threadName` and continue to render with just the space/channel source line.

## Consumer change (quorum-desktop)
A companion change on `feat/new-UI` resolves the thread title at bookmark-creation time — directly from `message.threadMeta.customTitle` when bookmarking a thread root, or via a single `messageDB.getMessageById(threadId)` lookup when bookmarking a reply. BookmarkCard renders the chip in the source-line breadcrumb after the channel/space.

## Test plan
- [x] Type compiles, dist rebuilt
- [ ] Verify in quorum-desktop: bookmark a thread root → breadcrumb shows the title; bookmark a thread reply → breadcrumb shows the title; bookmark a non-thread message → no breadcrumb chip.