### PR TITLE
feat(types): add DMUpdateProfileMessage control message type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export type {
   MessageSendStatus,
   PostMessage,
   UpdateProfileMessage,
+  DMUpdateProfileMessage,
   RemoveMessage,
   EventMessage,
   EmbedMessage,

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -1,3 +1,4 @@
+
 /**
  * Message-related types for Quorum
  */
@@ -27,6 +28,18 @@ export type UpdateProfileMessage = {
   userIcon: string;
   bio?: string;
   spaceTag?: BroadcastSpaceTag;
+};
+
+// DM equivalent of UpdateProfileMessage. Intercepted before persistence
+// (never renders as a chat post) and upserts the DM conversation row.
+// Empty/absent fields mean "no change"; explicit empty-string bio clears,
+// matching space update-profile semantics.
+export type DMUpdateProfileMessage = {
+  senderId: string;
+  type: 'dm-update-profile';
+  displayName?: string;
+  userIcon?: string;
+  bio?: string;
 };
 
 export type RemoveMessage = {


### PR DESCRIPTION
## Summary

Adds the wire-format type for broadcasting a sender's global profile (display name, avatar, bio) over an existing DM session.

- Sister type to the space-side `UpdateProfileMessage`, but receivers intercept it before persistence so it never renders as a chat post.
- Fields are optional — empty/absent means "no change" so partial updates don't clobber receivers' stored values. (Exception: explicit empty-string `bio` deliberately clears, matching space semantics.)
- Receivers must verify `senderId` equals the envelope sender address before applying (anti-spoofing).

Consumed by desktop and mobile DM receive paths to keep contact identity in sync after profile edits. Solves the case where a partner updates their pfp/bio/display name and the change never propagates to their DM contacts.

## Test plan

- [x] TypeScript check passes
- [ ] Desktop integration in follow-up PR (in progress)
- [ ] Mobile integration in follow-up PR (mirror implementation)