### PR TITLE
feat(types): add optional bio field to Conversation

### DIFF
--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -11,6 +11,9 @@ export type Conversation = {
   address: string;
   icon: string;
   displayName: string;
+  // DM partner's bio, received via DMUpdateProfileMessage. Mirrors the
+  // space-side per-member bio. Empty string = explicitly cleared.
+  bio?: string;
   lastReadTimestamp?: number;
   isRepudiable?: boolean;
   saveEditHistory?: boolean;


### PR DESCRIPTION
## Summary

Adds optional `bio?: string` to the `Conversation` type so DM contacts' bios can be persisted locally — same shape as the per-space-member bio in `space_members`.

Today the DM UserProfile sidebar reads bio only from the public-profile endpoint, which means partners who haven't opted in to public profiles never expose their bio in DMs. With this field, the upcoming desktop/mobile receive handler for `DMUpdateProfileMessage` can store bio on the conversation row, and the render path reads from there first (public-profile fallback second).

Optional and additive — no existing consumers are affected.

## Test plan

- [x] TypeScript check passes
- [ ] Desktop receive-side persists bio in a follow-up PR
- [ ] Desktop DM UserProfile sidebar prioritises conversation.bio in a follow-up PR
- [ ] Mobile parity in a follow-up PR