### PR TITLE
feat(qns): QNS resolver, name-resolution helper, .q name protection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-25",
+  "version": "2.1.0-26",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,3 +45,6 @@ export * from './farcaster';
 
 // Validation (errorKey-pattern field validators)
 export * from './validation';
+
+// QNS (Quilibrium Name Service — minimal resolution + address derivation)
+export * from './qns';

--- a/src/qns/deriveAddress.test.ts
+++ b/src/qns/deriveAddress.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { deriveAddress } from './deriveAddress';
+
+describe('deriveAddress', () => {
+  it('derives a Qm… address from a hex ed448 public key', () => {
+    // 57-byte ed448 public key, hex (114 hex chars)
+    const pubHex =
+      'a8b3f6c2d4e5061728394a5b6c7d8e9f0011223344556677889900aabbccddeeff' +
+      '00112233445566778899aabbccddee0011223344556677';
+    const addr = deriveAddress(pubHex);
+    expect(addr.startsWith('Qm')).toBe(true);
+    expect(addr.length).toBe(46);
+  });
+
+  it('accepts a 0x-prefixed hex string', () => {
+    const pubHex = '0x' + 'ab'.repeat(57);
+    expect(deriveAddress(pubHex).startsWith('Qm')).toBe(true);
+  });
+
+  it('accepts a Uint8Array', () => {
+    const bytes = new Uint8Array(57).fill(7);
+    expect(deriveAddress(bytes).startsWith('Qm')).toBe(true);
+  });
+
+  it('is deterministic', () => {
+    const bytes = new Uint8Array(57).fill(3);
+    expect(deriveAddress(bytes)).toBe(deriveAddress(bytes));
+  });
+
+  it('produces the canonical sha2-256 multihash signature (Qm + 44 base58 chars)', () => {
+    // sha2-256 multihash (0x12 0x20 + 32-byte digest) base58btc-encodes to
+    // exactly 46 chars starting "Qm" — the well-known IPFS CIDv0 shape.
+    const addr = deriveAddress(new Uint8Array(57).fill(1));
+    expect(addr).toMatch(/^Qm[1-9A-HJ-NP-Za-km-z]{44}$/);
+  });
+});

--- a/src/qns/deriveAddress.ts
+++ b/src/qns/deriveAddress.ts
@@ -1,0 +1,45 @@
+import { sha256 } from '@noble/hashes/sha2';
+import { base58btc } from 'multiformats/bases/base58';
+
+/**
+ * Derive a libp2p-style "Qm…" address from an ed448 public key.
+ *
+ * Mirrors quorum-mobile's `services/onboarding/keyService.ts` `deriveAddress`
+ * so both apps agree byte-for-byte: SHA-256 the key, wrap as a sha2-256
+ * multihash (code 0x12, length 0x20=32, then the digest), then base58btc-encode.
+ * The result is the canonical IPFS CIDv0 shape ("Qm" + 44 base58 chars).
+ *
+ * Mobile uses `multihashes` + `bs58`; shared has neither, so we build the
+ * multihash header inline and use `multiformats`' base58btc (same Bitcoin
+ * alphabet as `bs58`). The base58btc `encode` prepends the multibase prefix
+ * 'z', which we strip to get the raw "Qm…" address.
+ *
+ * @param publicKey - ed448 public key as a Uint8Array, or a hex string
+ *   (optionally `0x`-prefixed).
+ */
+export function deriveAddress(publicKey: Uint8Array | string): string {
+  const keyBytes =
+    typeof publicKey === 'string'
+      ? hexToBytes(publicKey.replace(/^0x/, ''))
+      : publicKey;
+
+  const digest = sha256(keyBytes);
+
+  // sha2-256 multihash: 0x12 (code) | 0x20 (length=32) | 32-byte digest
+  const multihash = new Uint8Array(2 + digest.length);
+  multihash[0] = 0x12;
+  multihash[1] = 0x20;
+  multihash.set(digest, 2);
+
+  // base58btc.encode returns a multibase string prefixed with 'z'; drop it.
+  return base58btc.encode(multihash).slice(1);
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.length % 2 ? '0' + hex : hex;
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}

--- a/src/qns/index.ts
+++ b/src/qns/index.ts
@@ -1,0 +1,2 @@
+export * from './resolver';
+export * from './deriveAddress';

--- a/src/qns/resolver.test.ts
+++ b/src/qns/resolver.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { resolveName, QNS_BASE_URL } from './resolver';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('resolveName', () => {
+  it('GETs /resolve/:name and returns the record', async () => {
+    const record = {
+      address: 'QmABC',
+      resolveKey: 'deadbeef',
+      metadata: null,
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => record,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await resolveName('alice');
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${QNS_BASE_URL}/resolve/alice`,
+      expect.any(Object)
+    );
+    expect(result?.address).toBe('QmABC');
+    expect(result?.resolveKey).toBe('deadbeef');
+  });
+
+  it('url-encodes the name', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ address: 'Q' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await resolveName('a b');
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${QNS_BASE_URL}/resolve/a%20b`,
+      expect.any(Object)
+    );
+  });
+
+  it('returns null on 404 (name not registered)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 404 })
+    );
+    expect(await resolveName('nope')).toBeNull();
+  });
+
+  it('throws on non-404 errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500 })
+    );
+    await expect(resolveName('x')).rejects.toThrow();
+  });
+});

--- a/src/qns/resolver.ts
+++ b/src/qns/resolver.ts
@@ -1,0 +1,32 @@
+export const QNS_BASE_URL = 'https://names.quilibrium.com';
+
+/**
+ * Minimal QNS name record — only the fields the username feature consumes.
+ * The full QNS record (mobile's `qnsClient.ts`) carries header/metadata/
+ * ownership, but resolution-for-display needs only the resolved address and
+ * the public key used to derive it.
+ */
+export interface QnsNameRecord {
+  /** The Qm… address the name's owner published. */
+  address: string;
+  /** Hex-encoded ed448 public key (57 bytes). Present when the name is
+   *  publicly resolvable; absent for privacy-stealth-only records. */
+  resolveKey?: string;
+  metadata?: Record<string, unknown> | null;
+}
+
+/**
+ * Resolve a single QNS name to its record. Returns null when the name is not
+ * registered (404). Throws on other transport/server errors so callers can
+ * distinguish "no such name" from "lookup failed". This is the ONLY QNS
+ * endpoint the username feature needs — registration/marketplace are excluded.
+ */
+export async function resolveName(name: string): Promise<QnsNameRecord | null> {
+  const res = await fetch(`${QNS_BASE_URL}/resolve/${encodeURIComponent(name)}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`QNS resolve failed: ${res.status}`);
+  return (await res.json()) as QnsNameRecord;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,6 +4,7 @@
 
 export * from './validation';
 export * from './mentions';
+export * from './resolveDisplayName';
 export * from './formatting';
 export * from './encoding';
 export * from './logger';

--- a/src/utils/resolveDisplayName.test.ts
+++ b/src/utils/resolveDisplayName.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { resolveDisplayName } from './resolveDisplayName';
+
+const base = { address: 'QmV5xWMo5CYSxgAAy6emKFZZPCKwCsBZKZxXD3mCUZF2nX' };
+
+describe('resolveDisplayName', () => {
+  it('uses the per-space override when present (highest priority)', () => {
+    const r = resolveDisplayName(
+      { ...base, display_name: 'NicMod', primary_username: 'alice', name: 'Alice' },
+      { spaceOverrideName: 'Nic (mod)' }
+    );
+    expect(r.name).toBe('Nic (mod)');
+    expect(r.isQnsVerified).toBe(false);
+  });
+
+  it('uses the QNS username when there is no space override', () => {
+    const r = resolveDisplayName(
+      { ...base, primary_username: 'alice', display_name: 'Whatever' },
+      {}
+    );
+    expect(r.name).toBe('alice');
+    expect(r.isQnsVerified).toBe(true);
+  });
+
+  it('falls back to the global display name when no override and no QNS name', () => {
+    const r = resolveDisplayName({ ...base, display_name: 'Alice A.' }, {});
+    expect(r.name).toBe('Alice A.');
+    expect(r.isQnsVerified).toBe(false);
+  });
+
+  it('falls back to `name` then truncated address when nothing else exists', () => {
+    const r = resolveDisplayName({ ...base }, {});
+    expect(r.isQnsVerified).toBe(false);
+    expect(r.name.startsWith('Qm')).toBe(true);
+    expect(r.name.length).toBeLessThan(base.address.length); // truncated
+  });
+
+  it('uses `name` over the truncated address when display_name is absent', () => {
+    const r = resolveDisplayName({ ...base, name: 'legacy-name' }, {});
+    expect(r.name).toBe('legacy-name');
+    expect(r.isQnsVerified).toBe(false);
+  });
+
+  it('treats empty/whitespace names as absent', () => {
+    const r = resolveDisplayName(
+      { ...base, display_name: '   ', primary_username: 'alice' },
+      { spaceOverrideName: '  ' }
+    );
+    expect(r.name).toBe('alice');
+    expect(r.isQnsVerified).toBe(true);
+  });
+
+  it('never returns an empty name', () => {
+    const r = resolveDisplayName({ address: 'QmShort' }, {});
+    expect(r.name.length).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/resolveDisplayName.ts
+++ b/src/utils/resolveDisplayName.ts
@@ -1,0 +1,55 @@
+import type { SpaceMember, PublicProfile } from '../types/user';
+
+/**
+ * The subset of member/profile fields the name-resolution rule reads.
+ * Accepts any object carrying these (SpaceMember, PublicProfile, or a partial).
+ */
+export type Resolvable = Partial<
+  Pick<SpaceMember & PublicProfile, 'display_name' | 'name' | 'primary_username'>
+> & {
+  address: string;
+};
+
+export interface ResolvedName {
+  /** The readable name to display. Never empty. */
+  name: string;
+  /** True only when `name` is the user's QNS username (render with `.q`). */
+  isQnsVerified: boolean;
+}
+
+const present = (s?: string | null): string | null => {
+  const t = (s ?? '').trim();
+  return t.length ? t : null;
+};
+
+const truncate = (addr: string): string =>
+  addr.length > 10 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
+
+/**
+ * The single name-resolution rule for the whole app. Most-specific wins:
+ *
+ *   per-space override → QNS primary_username → global display name → name → address
+ *
+ * Pure and platform-agnostic. The `.q` suffix and accent styling are applied by
+ * the rendering layer based on `isQnsVerified`, not baked into `name`. This
+ * function is the single source of truth so the four surfaces (profile card,
+ * DM header, mention pill, mention autocomplete) can never drift apart.
+ */
+export function resolveDisplayName(
+  member: Resolvable,
+  opts: { spaceOverrideName?: string | null } = {}
+): ResolvedName {
+  const override = present(opts.spaceOverrideName);
+  if (override) return { name: override, isQnsVerified: false };
+
+  const qns = present(member.primary_username);
+  if (qns) return { name: qns, isQnsVerified: true };
+
+  const display = present(member.display_name);
+  if (display) return { name: display, isQnsVerified: false };
+
+  const name = present(member.name);
+  if (name) return { name, isQnsVerified: false };
+
+  return { name: truncate(member.address), isQnsVerified: false };
+}

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -209,6 +209,19 @@ describe('Reserved Name Validation', () => {
       expect(getReservedNameType('support')).toBe('impersonation');
     });
 
+    it('should return "qns-suffix" for any dotted name (protects the .q verified marker)', () => {
+      expect(getReservedNameType('alice.q')).toBe('qns-suffix');
+      expect(getReservedNameType('foo.bar')).toBe('qns-suffix');
+      expect(getReservedNameType('alice．q')).toBe('qns-suffix'); // U+FF0E
+      expect(getReservedNameType('alice﹒q')).toBe('qns-suffix'); // U+FE52
+      expect(getReservedNameType('alice.q ')).toBe('qns-suffix'); // trailing space
+    });
+
+    it('checks the dot rule before impersonation/mention (specific error wins)', () => {
+      // "admin.q" is both dotted and impersonation-shaped; dot rule should win.
+      expect(getReservedNameType('admin.q')).toBe('qns-suffix');
+    });
+
     it('should return null for allowed names', () => {
       expect(getReservedNameType('John')).toBe(null);
       expect(getReservedNameType('sysadmin')).toBe(null);

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -269,26 +269,51 @@ export const isMentionReserved = (name: string): boolean => {
 export const isEveryoneReserved = isMentionReserved;
 
 /**
+ * Confusable dot characters that must be folded to '.' before the dot check,
+ * so a lookalike (full-width '．' U+FF0E, small '﹒' U+FE52, one-dot-leader '․'
+ * U+2024) can't smuggle a fake ".q" past validation.
+ */
+const CONFUSABLE_DOTS = /[.．﹒․]/g;
+
+/**
+ * QNS names are dotless, and the ".q" suffix is appended only at render time as
+ * a verified-name trust marker. A custom display name therefore has no
+ * legitimate reason to contain a dot — allowing one would let a user spoof the
+ * ".q" marker (e.g. "admin.q"). Normalize confusable dots + trim, then reject
+ * any remaining dot.
+ *
+ * @param name - The raw custom name to check
+ * @returns true if the normalized name contains a dot
+ */
+export const containsReservedDot = (name: string): boolean =>
+  name.replace(CONFUSABLE_DOTS, '.').trim().includes('.');
+
+/**
  * Result of reserved name check with specific type for error messaging.
+ * - 'qns-suffix': Contains a dot — reserved for verified QNS names (".q")
  * - 'mention': Conflicts with @everyone or @here mentions
  * - 'impersonation': Resembles admin/moderator/support names
  */
-export type ReservedNameType = 'mention' | 'impersonation' | null;
+export type ReservedNameType = 'mention' | 'impersonation' | 'qns-suffix' | null;
 
 /**
  * Checks if a name is reserved and returns the type of reservation.
- * Combines both mention keyword check and impersonation check.
+ * Combines the QNS dot rule, mention keyword check, and impersonation check.
+ * The dot rule is checked first so a dotted name (which can never be a valid
+ * custom name) yields the specific "qns-suffix" reason.
  *
  * @param name - The name to check
  * @returns The type of reservation or null if not reserved
  *
  * @example
+ * getReservedNameType("alice.q") // 'qns-suffix'
  * getReservedNameType("everyone") // 'mention'
  * getReservedNameType("here") // 'mention'
  * getReservedNameType("admin") // 'impersonation'
  * getReservedNameType("John") // null
  */
 export const getReservedNameType = (name: string): ReservedNameType => {
+  if (containsReservedDot(name)) return 'qns-suffix';
   if (isMentionReserved(name)) return 'mention';
   if (isImpersonationName(name)) return 'impersonation';
   return null;

--- a/src/validation/displayName.ts
+++ b/src/validation/displayName.ts
@@ -7,6 +7,8 @@
  *   on display names at all; pre-refactor desktop only required non-empty)
  * - No mention-reserved names (everyone, here, mod, manager)
  * - No impersonation names (admin, moderator, etc., including homoglyph variants)
+ * - No dots (the ".q" suffix is reserved for verified QNS names; allowing a dot
+ *   in a custom name would let it spoof the verified-name marker)
  * - No dangerous HTML patterns (XSS defense-in-depth)
  */
 
@@ -30,6 +32,9 @@ export function validateDisplayName(displayName: string): FieldValidationResult 
     };
   }
   const reservedType = getReservedNameType(displayName);
+  if (reservedType === 'qns-suffix') {
+    return { ok: false, errorKey: 'displayName.reservedQnsSuffix' };
+  }
   if (reservedType === 'mention') {
     return { ok: false, errorKey: 'displayName.reservedMention' };
   }

--- a/src/validation/validators.test.ts
+++ b/src/validation/validators.test.ts
@@ -116,6 +116,42 @@ describe('validateDisplayName', () => {
       errorKey: 'displayName.invalidChars',
     });
   });
+
+  it('rejects names ending in .q (reserved for verified QNS names)', () => {
+    expect(validateDisplayName('alice.q')).toEqual({
+      ok: false,
+      errorKey: 'displayName.reservedQnsSuffix',
+    });
+  });
+
+  it('rejects any dotted name (dots reserved for QNS)', () => {
+    expect(validateDisplayName('foo.bar')).toEqual({
+      ok: false,
+      errorKey: 'displayName.reservedQnsSuffix',
+    });
+  });
+
+  it('rejects lookalike/full-width dot bypasses', () => {
+    expect(validateDisplayName('alice．q')).toEqual({
+      ok: false,
+      errorKey: 'displayName.reservedQnsSuffix',
+    }); // U+FF0E fullwidth dot
+    expect(validateDisplayName('alice﹒q')).toEqual({
+      ok: false,
+      errorKey: 'displayName.reservedQnsSuffix',
+    }); // U+FE52 small full stop
+  });
+
+  it('rejects trailing-space bypass on a dotted name', () => {
+    expect(validateDisplayName('alice.q ')).toEqual({
+      ok: false,
+      errorKey: 'displayName.reservedQnsSuffix',
+    });
+  });
+
+  it('still accepts ordinary names without dots', () => {
+    expect(validateDisplayName('Alice A')).toEqual({ ok: true });
+  });
 });
 
 describe('validateChannelName', () => {


### PR DESCRIPTION
## What

Additive-only foundation for the desktop **QNS-usernames** feature. Stage 1 of the plan in `quorum-desktop/.agents/tasks/port-from-mobile/2026-06-10-qns-username-display-plan.md`.

- **`src/qns/`** — minimal QNS resolver. `resolveName(name)` → `GET /resolve/:name` only (1 of ~25 endpoints; registration/marketplace excluded). `deriveAddress(pubkey)` derives a `Qm…` address from an ed448 public key, mirroring mobile's `keyService.deriveAddress` but using `multiformats` + `@noble/hashes` (already deps) instead of adding `bs58`/`multihashes`.
- **`src/utils/resolveDisplayName.ts`** — the single name-resolution rule for all four desktop surfaces (DM header, profile card, mention pill, mention autocomplete): per-space override → QNS `primary_username` → global display name → `name` → truncated address. Pure, platform-agnostic, returns `{ name, isQnsVerified }`. The `.q` suffix + accent styling are applied by the render layer, not baked in.
- **validation** — `getReservedNameType` now returns `'qns-suffix'` for any dotted custom name (new `displayName.reservedQnsSuffix` errorKey), with confusable-dot normalization (full-width `．`, small `﹒`, one-dot-leader `․`) + trim before the check. This makes the render-time `.q` verified marker unspoofable. Only `validateDisplayName` consumes `getReservedNameType`, so space/channel names are unaffected.

## Reviewability

Strictly additive: new files + one new optional reserved type (`'qns-suffix'`) + one new errorKey. No existing export signatures change, so nothing that already consumes shared can break.

## Tests

Full suite green: **260 passed**. New: 5 deriveAddress, 4 resolver, 7 resolveDisplayName, 6 dot-rule. Typecheck + build clean.

Version bumped `2.1.0-25` → `2.1.0-26`.