### PR TITLE
fix(validation): narrow QNS name guard to the .q suffix only

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-26",
+  "version": "2.1.0-27",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -209,16 +209,23 @@ describe('Reserved Name Validation', () => {
       expect(getReservedNameType('support')).toBe('impersonation');
     });
 
-    it('should return "qns-suffix" for any dotted name (protects the .q verified marker)', () => {
+    it('should return "qns-suffix" only for names ending in ".q" (protects the verified marker)', () => {
       expect(getReservedNameType('alice.q')).toBe('qns-suffix');
-      expect(getReservedNameType('foo.bar')).toBe('qns-suffix');
       expect(getReservedNameType('alice．q')).toBe('qns-suffix'); // U+FF0E
       expect(getReservedNameType('alice﹒q')).toBe('qns-suffix'); // U+FE52
       expect(getReservedNameType('alice.q ')).toBe('qns-suffix'); // trailing space
+      expect(getReservedNameType('ALICE.Q')).toBe('qns-suffix'); // case-insensitive
     });
 
-    it('checks the dot rule before impersonation/mention (specific error wins)', () => {
-      // "admin.q" is both dotted and impersonation-shaped; dot rule should win.
+    it('should allow a mid-name dot (e.g. "jane.doe") — only ".q" endings are reserved', () => {
+      expect(getReservedNameType('jane.doe')).toBe(null);
+      expect(getReservedNameType('foo.bar')).toBe(null);
+      expect(getReservedNameType('J.R.R.')).toBe(null);
+      expect(getReservedNameType('a.qb')).toBe(null); // ".q" not at the end
+    });
+
+    it('checks the .q-suffix rule before impersonation/mention (specific error wins)', () => {
+      // "admin.q" is both ".q"-suffixed and impersonation-shaped; suffix wins.
       expect(getReservedNameType('admin.q')).toBe('qns-suffix');
     });
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -269,28 +269,29 @@ export const isMentionReserved = (name: string): boolean => {
 export const isEveryoneReserved = isMentionReserved;
 
 /**
- * Confusable dot characters that must be folded to '.' before the dot check,
+ * Confusable dot characters that must be folded to '.' before the suffix check,
  * so a lookalike (full-width '．' U+FF0E, small '﹒' U+FE52, one-dot-leader '․'
  * U+2024) can't smuggle a fake ".q" past validation.
  */
 const CONFUSABLE_DOTS = /[.．﹒․]/g;
 
 /**
- * QNS names are dotless, and the ".q" suffix is appended only at render time as
- * a verified-name trust marker. A custom display name therefore has no
- * legitimate reason to contain a dot — allowing one would let a user spoof the
- * ".q" marker (e.g. "admin.q"). Normalize confusable dots + trim, then reject
- * any remaining dot.
+ * Verified QNS names are rendered as "<name>.q" at display time, where <name>
+ * is dotless (QNS forbids dots in names). The ONLY custom string that could be
+ * mistaken for a verified handle is therefore one ending in ".q". A dot
+ * elsewhere (e.g. "jane.doe") is harmless — it can't look like a verified name —
+ * so we don't block it. Normalize confusable dots + trim, then reject only a
+ * trailing ".q".
  *
  * @param name - The raw custom name to check
- * @returns true if the normalized name contains a dot
+ * @returns true if the normalized name ends in ".q"
  */
-export const containsReservedDot = (name: string): boolean =>
-  name.replace(CONFUSABLE_DOTS, '.').trim().includes('.');
+export const hasReservedQnsSuffix = (name: string): boolean =>
+  name.replace(CONFUSABLE_DOTS, '.').trim().toLowerCase().endsWith('.q');
 
 /**
  * Result of reserved name check with specific type for error messaging.
- * - 'qns-suffix': Contains a dot — reserved for verified QNS names (".q")
+ * - 'qns-suffix': Ends in ".q" — reserved for verified QNS names
  * - 'mention': Conflicts with @everyone or @here mentions
  * - 'impersonation': Resembles admin/moderator/support names
  */
@@ -298,22 +299,23 @@ export type ReservedNameType = 'mention' | 'impersonation' | 'qns-suffix' | null
 
 /**
  * Checks if a name is reserved and returns the type of reservation.
- * Combines the QNS dot rule, mention keyword check, and impersonation check.
- * The dot rule is checked first so a dotted name (which can never be a valid
- * custom name) yields the specific "qns-suffix" reason.
+ * Combines the QNS ".q"-suffix rule, mention keyword check, and impersonation
+ * check. The suffix rule is checked first so a name ending in ".q" yields the
+ * specific "qns-suffix" reason. A dot elsewhere (e.g. "jane.doe") is allowed.
  *
  * @param name - The name to check
  * @returns The type of reservation or null if not reserved
  *
  * @example
  * getReservedNameType("alice.q") // 'qns-suffix'
+ * getReservedNameType("jane.doe") // null (mid-name dot is fine)
  * getReservedNameType("everyone") // 'mention'
  * getReservedNameType("here") // 'mention'
  * getReservedNameType("admin") // 'impersonation'
  * getReservedNameType("John") // null
  */
 export const getReservedNameType = (name: string): ReservedNameType => {
-  if (containsReservedDot(name)) return 'qns-suffix';
+  if (hasReservedQnsSuffix(name)) return 'qns-suffix';
   if (isMentionReserved(name)) return 'mention';
   if (isImpersonationName(name)) return 'impersonation';
   return null;

--- a/src/validation/displayName.ts
+++ b/src/validation/displayName.ts
@@ -7,8 +7,9 @@
  *   on display names at all; pre-refactor desktop only required non-empty)
  * - No mention-reserved names (everyone, here, mod, manager)
  * - No impersonation names (admin, moderator, etc., including homoglyph variants)
- * - No dots (the ".q" suffix is reserved for verified QNS names; allowing a dot
- *   in a custom name would let it spoof the verified-name marker)
+ * - No ".q" suffix (reserved for verified QNS names; a name ending in ".q"
+ *   would spoof the verified-name marker — a mid-name dot like "jane.doe" is
+ *   fine since it can't look like a verified handle)
  * - No dangerous HTML patterns (XSS defense-in-depth)
  */
 

--- a/src/validation/validators.test.ts
+++ b/src/validation/validators.test.ts
@@ -124,14 +124,11 @@ describe('validateDisplayName', () => {
     });
   });
 
-  it('rejects any dotted name (dots reserved for QNS)', () => {
-    expect(validateDisplayName('foo.bar')).toEqual({
-      ok: false,
-      errorKey: 'displayName.reservedQnsSuffix',
-    });
+  it('allows a mid-name dot (only ".q" endings are reserved)', () => {
+    expect(validateDisplayName('jane.doe')).toEqual({ ok: true });
   });
 
-  it('rejects lookalike/full-width dot bypasses', () => {
+  it('rejects lookalike/full-width dot bypasses on the .q suffix', () => {
     expect(validateDisplayName('alice．q')).toEqual({
       ok: false,
       errorKey: 'displayName.reservedQnsSuffix',
@@ -142,7 +139,7 @@ describe('validateDisplayName', () => {
     }); // U+FE52 small full stop
   });
 
-  it('rejects trailing-space bypass on a dotted name', () => {
+  it('rejects trailing-space bypass on a .q suffix', () => {
     expect(validateDisplayName('alice.q ')).toEqual({
       ok: false,
       errorKey: 'displayName.reservedQnsSuffix',


### PR DESCRIPTION
## What

Follow-up to #35. The reserved-name guard added there rejected **any** dot in a custom display name. That was over-broad: it regressed legitimate, previously-allowed names like `jane.doe` (neither desktop nor mobile validated dots before this feature), for no security gain.

The only string that can be mistaken for a verified QNS handle is one ending in **`.q`** — verified names render as `<name>.q` where `<name>` is dotless (QNS forbids dots in names). A mid-name dot can't look like a verified handle, so it's safe to allow.

## Change

- `containsReservedDot` → **`hasReservedQnsSuffix`**: trim + lowercase + fold confusable dots (`．` `﹒` `․`), then `endsWith('.q')`.
- `jane.doe` / `J.R.R.` now valid; `alice.q`, `ALICE.Q`, `alice．q` (lookalike dot) still rejected.
- `getReservedNameType` still returns `'qns-suffix'` for the `.q` case; error key unchanged.

## Reviewability

Strictly **more permissive** than #35 — it only stops rejecting some inputs, never starts rejecting new ones — so nothing that consumes shared can break.

## Tests

Full suite green: **261 passed**. Updated the dot tests to assert mid-name dots are allowed and only `.q` endings are blocked. Bumped `2.1.0-26` → `2.1.0-27`.