### PR TITLE
feat(validation): enforce Farcaster byte limits on display name and bio

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-27",
+  "version": "2.1.0-28",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -67,6 +67,21 @@ export const MAX_MESSAGE_LENGTH = 2500;
 /** Maximum number of mentions per message */
 export const MAX_MENTIONS = 50;
 
+/**
+ * UTF-8 byte length of a string.
+ *
+ * Some limits are dictated by external systems that count bytes, not
+ * JS string `.length` (UTF-16 code units). Farcaster's USER_DATA fields are
+ * the motivating case: a display name is capped at 32 bytes and a bio at 256
+ * bytes (see the Farcaster protocol SPECIFICATION). Counting characters would
+ * pass values locally that the Farcaster relay then rejects on publish, since
+ * one emoji is up to 4 bytes and an accented letter like "é" is 2 bytes.
+ *
+ * Use this for any field whose true constraint is a byte budget.
+ */
+export const byteLength = (value: string): number =>
+  new TextEncoder().encode(value).length;
+
 /** Validation result */
 export interface ValidationResult {
   valid: boolean;

--- a/src/validation/displayName.ts
+++ b/src/validation/displayName.ts
@@ -3,8 +3,14 @@
  *
  * Rules (verified against mobile + pre-refactor desktop, 2026-05-28):
  * - Required (non-empty after trim)
- * - Maximum length: MAX_NAME_LENGTH (no minimum — mobile has no validation
- *   on display names at all; pre-refactor desktop only required non-empty)
+ * - Maximum length: MAX_DISPLAY_NAME_BYTES (32 UTF-8 bytes, no minimum —
+ *   mobile has no validation on display names at all; pre-refactor desktop
+ *   only required non-empty). The limit is in BYTES, not characters, to match
+ *   Farcaster's USER_DATA_TYPE_DISPLAY constraint (<= 32 bytes): a Quorum
+ *   profile can be published to Farcaster, so a name Farcaster would reject
+ *   must be rejected here too. We count bytes because one emoji is up to 4
+ *   bytes and an accented letter is 2 — a character count would let through
+ *   names the Farcaster relay then rejects on publish.
  * - No mention-reserved names (everyone, here, mod, manager)
  * - No impersonation names (admin, moderator, etc., including homoglyph variants)
  * - No ".q" suffix (reserved for verified QNS names; a name ending in ".q"
@@ -14,23 +20,26 @@
  */
 
 import {
-  MAX_NAME_LENGTH,
+  byteLength,
   validateNameForXSS,
   getReservedNameType,
 } from '../utils/validation';
 import type { FieldValidationResult } from './result';
+
+/**
+ * Maximum display name length in UTF-8 bytes.
+ * Matches Farcaster's USER_DATA_TYPE_DISPLAY limit (<= 32 bytes) so a Quorum
+ * display name is always accepted when published to a merged Farcaster profile.
+ */
+export const MAX_DISPLAY_NAME_BYTES = 32;
 
 export function validateDisplayName(displayName: string): FieldValidationResult {
   const trimmed = displayName.trim();
   if (!trimmed) {
     return { ok: false, errorKey: 'displayName.required' };
   }
-  if (displayName.length > MAX_NAME_LENGTH) {
-    return {
-      ok: false,
-      errorKey: 'displayName.tooLong',
-      errorVars: { max: MAX_NAME_LENGTH },
-    };
+  if (byteLength(trimmed) > MAX_DISPLAY_NAME_BYTES) {
+    return { ok: false, errorKey: 'displayName.tooLong' };
   }
   const reservedType = getReservedNameType(displayName);
   if (reservedType === 'qns-suffix') {

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -18,10 +18,10 @@ export { isValidField } from './result';
 
 export { validateSpaceName } from './spaceName';
 export { validateSpaceDescription } from './spaceDescription';
-export { validateDisplayName } from './displayName';
+export { validateDisplayName, MAX_DISPLAY_NAME_BYTES } from './displayName';
 export { validateChannelName } from './channelName';
 export { validateChannelTopic } from './channelTopic';
 export { validateGroupName } from './groupName';
 export { validateDeviceName, DEVICE_NAME_PATTERN } from './deviceName';
-export { validateUserBio, MAX_BIO_LENGTH } from './userBio';
+export { validateUserBio, MAX_BIO_BYTES } from './userBio';
 export { validateUserNote, MAX_USER_NOTE_LENGTH } from './userNote';

--- a/src/validation/userBio.ts
+++ b/src/validation/userBio.ts
@@ -6,14 +6,17 @@
  * all violations).
  */
 
-import { validateNameForXSS } from '../utils/validation';
+import { byteLength, validateNameForXSS } from '../utils/validation';
 import type { FieldValidationResult } from './result';
 
 /**
- * Maximum length for user bio/description.
- * Matches mobile app limit for consistency.
+ * Maximum bio length in UTF-8 bytes.
+ * Matches Farcaster's USER_DATA_TYPE_BIO limit (<= 256 bytes) so a Quorum bio
+ * is always accepted when published to a merged Farcaster profile. Counted in
+ * bytes, not characters, because one emoji is up to 4 bytes and an accented
+ * letter is 2 — a character count would pass bios the Farcaster relay rejects.
  */
-export const MAX_BIO_LENGTH = 160;
+export const MAX_BIO_BYTES = 256;
 
 export function validateUserBio(bio: string): FieldValidationResult[] {
   const errors: FieldValidationResult[] = [];
@@ -21,12 +24,8 @@ export function validateUserBio(bio: string): FieldValidationResult[] {
   if (!validateNameForXSS(bio)) {
     errors.push({ ok: false, errorKey: 'userBio.invalidChars' });
   }
-  if (bio.length > MAX_BIO_LENGTH) {
-    errors.push({
-      ok: false,
-      errorKey: 'userBio.tooLong',
-      errorVars: { max: MAX_BIO_LENGTH },
-    });
+  if (byteLength(bio) > MAX_BIO_BYTES) {
+    errors.push({ ok: false, errorKey: 'userBio.tooLong' });
   }
 
   return errors;

--- a/src/validation/validators.test.ts
+++ b/src/validation/validators.test.ts
@@ -9,7 +9,8 @@ import {
   validateDeviceName,
   validateUserBio,
   validateUserNote,
-  MAX_BIO_LENGTH,
+  MAX_BIO_BYTES,
+  MAX_DISPLAY_NAME_BYTES,
   MAX_USER_NOTE_LENGTH,
   isValidField,
 } from './index';
@@ -83,12 +84,27 @@ describe('validateDisplayName', () => {
     expect(validateDisplayName('a')).toEqual({ ok: true });
   });
 
-  it('rejects too long', () => {
-    const long = 'a'.repeat(MAX_NAME_LENGTH + 1);
+  it('rejects too long (over the byte budget)', () => {
+    const long = 'a'.repeat(MAX_DISPLAY_NAME_BYTES + 1);
     expect(validateDisplayName(long)).toEqual({
       ok: false,
       errorKey: 'displayName.tooLong',
-      errorVars: { max: MAX_NAME_LENGTH },
+    });
+  });
+
+  it('accepts a name exactly at the byte budget', () => {
+    const exact = 'a'.repeat(MAX_DISPLAY_NAME_BYTES);
+    expect(validateDisplayName(exact)).toEqual({ ok: true });
+  });
+
+  it('counts bytes, not characters: a multi-byte name shorter than the budget in chars can still be too long', () => {
+    // Each "😀" is 4 UTF-8 bytes. 9 of them = 36 bytes > 32, but only 18 UTF-16
+    // code units / 9 visible chars — a character-based check would wrongly pass.
+    const emoji = '😀'.repeat(9);
+    expect(emoji.length).toBeLessThan(MAX_DISPLAY_NAME_BYTES);
+    expect(validateDisplayName(emoji)).toEqual({
+      ok: false,
+      errorKey: 'displayName.tooLong',
     });
   });
 
@@ -265,11 +281,21 @@ describe('validateUserBio', () => {
     expect(validateUserBio('Hello world')).toEqual([]);
   });
 
-  it('rejects too long', () => {
-    const errors = validateUserBio('a'.repeat(MAX_BIO_LENGTH + 1));
-    expect(errors).toEqual([
-      { ok: false, errorKey: 'userBio.tooLong', errorVars: { max: MAX_BIO_LENGTH } },
-    ]);
+  it('rejects too long (over the byte budget)', () => {
+    const errors = validateUserBio('a'.repeat(MAX_BIO_BYTES + 1));
+    expect(errors).toEqual([{ ok: false, errorKey: 'userBio.tooLong' }]);
+  });
+
+  it('accepts a bio exactly at the byte budget', () => {
+    expect(validateUserBio('a'.repeat(MAX_BIO_BYTES))).toEqual([]);
+  });
+
+  it('counts bytes, not characters: a multi-byte bio shorter than the budget in chars can still be too long', () => {
+    // Each "😀" is 4 UTF-8 bytes. 65 of them = 260 bytes > 256, but only 130
+    // UTF-16 code units — a character-based check would wrongly pass.
+    const emoji = '😀'.repeat(65);
+    expect(emoji.length).toBeLessThan(MAX_BIO_BYTES);
+    expect(validateUserBio(emoji)).toEqual([{ ok: false, errorKey: 'userBio.tooLong' }]);
   });
 
   it('rejects HTML injection', () => {


### PR DESCRIPTION
## What

Display name and bio can be published to a merged Farcaster profile (mobile's `UnifiedProfileEditModal` PATCHes `client.farcaster.xyz/v2/me`). Farcaster's `USER_DATA` fields are capped in **bytes**, so a value that passes our character-based check can still be rejected by the relay on publish.

This switches both validators to count UTF-8 bytes:

| Field | Farcaster type | Limit |
|---|---|---|
| Display name | `USER_DATA_TYPE_DISPLAY` | `MAX_DISPLAY_NAME_BYTES` = **32 bytes** |
| Bio | `USER_DATA_TYPE_BIO` | `MAX_BIO_BYTES` = **256 bytes** (was 160 chars) |

## Why bytes, not characters

`bio.length` counts UTF-16 code units. One emoji is up to 4 bytes; an accented `é` is 2. A character cap of 256 lets through bios up to ~1 KB, which Farcaster rejects. Byte counting is the only measure that matches the real downstream constraint.

## Changes
- Add `byteLength()` helper (`TextEncoder`) in `utils/validation.ts`
- `displayName.ts`: 32-byte cap via new `MAX_DISPLAY_NAME_BYTES` (was generic `MAX_NAME_LENGTH` = 50 chars; that constant is untouched for space/channel/group/device names)
- `userBio.ts`: 256-byte cap via new `MAX_BIO_BYTES`; **`MAX_BIO_LENGTH` removed** (no remaining consumers — mobile uses hardcoded literals)
- Too-long errors drop the numeric `errorVars`: a byte count is meaningless to show a user, so desktop renders a plain "too long" message
- Tests updated + emoji byte-vs-char cases added

## User-visible
- Bio limit rises 160 → 256 bytes (more room for ASCII users)
- Display name tightens 50 chars → 32 bytes: existing 33-50 char names become invalid on next edit. Accepted tradeoff for one consistent, Farcaster-ready rule.

## Verification
- `yarn test` → 265 passing
- `yarn build` → green

## Follow-ups (separate)
- Desktop: consume new limits (validator messages, `maxLength` guards, counters) — in progress this session
- Mobile: converge the three bio caps (160/256/280) + two display-name caps (50/60) to shared, adopt `validateUserBio`/`validateDisplayName`, hard-block at the Farcaster publish boundary