### PR TITLE
feat(input): optional leftIcon/rightIcon slots on the Input primitive

### DIFF
--- a/src/primitives/Input/Input.native.tsx
+++ b/src/primitives/Input/Input.native.tsx
@@ -28,6 +28,8 @@ export const Input: React.FC<InputNativeProps> = ({
   labelType = 'static',
   required = false,
   helperText,
+  leftIcon,
+  rightIcon,
 }) => {
   const theme = useTheme();
   const colors = theme.colors;
@@ -157,9 +159,23 @@ export const Input: React.FC<InputNativeProps> = ({
       )}
 
       {/* Input container for floating label */}
-      <View style={showFloatingLabel ? styles.floatingContainer : undefined}>
+      <View
+        style={[
+          (showFloatingLabel || leftIcon || rightIcon) && styles.floatingContainer,
+        ]}
+      >
+        {leftIcon && (
+          <View style={[styles.icon, styles.iconLeft]} pointerEvents="box-none">
+            {leftIcon}
+          </View>
+        )}
+
         <TextInput
-          style={inputStyle}
+          style={[
+            inputStyle,
+            !!leftIcon && styles.inputWithLeftIcon,
+            !!rightIcon && styles.inputWithRightIcon,
+          ]}
           value={value}
           placeholder={
             showFloatingLabel
@@ -182,6 +198,12 @@ export const Input: React.FC<InputNativeProps> = ({
           testID={testID}
           accessibilityLabel={accessibilityLabel || label}
         />
+
+        {rightIcon && (
+          <View style={[styles.icon, styles.iconRight]} pointerEvents="box-none">
+            {rightIcon}
+          </View>
+        )}
 
         {/* Floating Label - only show when active (focused or has value) */}
         {showFloatingLabel && (isFocused || hasValue) && (
@@ -245,6 +267,27 @@ const styles = StyleSheet.create({
   inputWithFloatingLabel: {
     // Keep same padding as normal input
     // Floating label positions itself over the border
+  },
+  inputWithLeftIcon: {
+    paddingLeft: 40,
+  },
+  inputWithRightIcon: {
+    paddingRight: 40,
+  },
+  icon: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    height: 42,
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: 40,
+  },
+  iconLeft: {
+    left: 0,
+  },
+  iconRight: {
+    right: 0,
   },
   inputMinimal: {
     borderRadius: 0,

--- a/src/primitives/Input/Input.web.tsx
+++ b/src/primitives/Input/Input.web.tsx
@@ -25,6 +25,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
   required = false,
   helperText,
   clearable = false,
+  leftIcon,
+  rightIcon,
 }, ref) => {
   const [isFocused, setIsFocused] = useState(false);
   const inputId = useId();
@@ -80,9 +82,15 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
         className={clsx(
           'input-wrapper',
           className,
-          clearable && hasValue && !disabled && 'input-has-clear'
+          clearable && hasValue && !disabled && 'input-has-clear',
+          !!leftIcon && 'input-has-left-icon',
+          !!rightIcon && 'input-has-right-icon'
         )}
       >
+        {leftIcon && (
+          <span className="input-icon input-icon--left">{leftIcon}</span>
+        )}
+
         <input
           ref={ref}
           id={inputId}
@@ -117,6 +125,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
           >
             ×
           </button>
+        )}
+
+        {rightIcon && (
+          <span className="input-icon input-icon--right">{rightIcon}</span>
         )}
 
         {/* Floating Label - only show when active (focused or has value) */}

--- a/src/primitives/Input/types.ts
+++ b/src/primitives/Input/types.ts
@@ -45,6 +45,18 @@ export interface InputProps {
   helperText?: string;
   /** Show a clear (×) control when there is input (web only) */
   clearable?: boolean;
+  /**
+   * Icon/element rendered inside the field, before the text (left side).
+   * The consumer passes its own node (e.g. an <Icon /> or a clickable button).
+   * The input is automatically padded to make room.
+   */
+  leftIcon?: React.ReactNode;
+  /**
+   * Icon/element rendered inside the field, after the text (right side).
+   * Useful for reveal toggles, status indicators, or actions.
+   * The input is automatically padded to make room.
+   */
+  rightIcon?: React.ReactNode;
 }
 
 // React Native specific props


### PR DESCRIPTION
## What

Adds two **optional** props to the `Input` primitive: `leftIcon` and `rightIcon` (each a `React.ReactNode`). They render a consumer-provided node inside the field, on the left or right side.

## Why

Consumers needed to place an icon/affordance *inside* a field (e.g. a password reveal toggle, a search icon, a status indicator). Previously this meant absolutely-positioning a sibling element over the input with hardcoded pixel offsets, which always looked bolted-on and broke when the field height/padding changed. An in-primitive slot renders inside the field's own flex container, so it shares the field's exact height, padding and border-radius and reserves its own space.

First consumer: quorum-desktop's onboarding 'paste private key' field uses `rightIcon` for the show/hide eye toggle.

## How

- **types.ts** — `leftIcon?` / `rightIcon?` added to `InputProps` (inherited by `InputNativeProps`).
- **Input.web.tsx** — renders the nodes inside `.input-wrapper`; adds marker classes `input-has-left-icon` / `input-has-right-icon` and `input-icon input-icon--left|right` so the **consuming app's** stylesheet positions them and pads the input. (No CSS ships from quorum-shared; each app already styles the primitive.)
- **Input.native.tsx** — renders the nodes in absolutely-positioned views with built-in padding on the `TextInput`.

## Compatibility

**Strictly additive, non-breaking.** When neither prop is passed, the rendered output is byte-for-byte identical to before (no extra wrapper nodes, no class changes, no layout shift). Mobile, which pins to the published package, is unaffected until it opts in.

## Notes for reviewers

- Web styling (positioning + input padding) lives in the consumer app, intentionally — quorum-shared ships structure, apps ship the look. The desktop side adds `.input-icon` rules + `input-has-{left,right}-icon` padding in its own `Input.scss` (separate desktop PR).
- An interactive child (e.g. a `<button>` reveal toggle) works: the web wrapper sets `pointer-events: none` decoratively but re-enables it for interactive children via the app CSS.
- Playground: a 'Left Icon' and 'Right Icon' example were added to the desktop primitives playground (in the desktop PR) for visual verification.