### PR TITLE
feat(types): add primaryUsername to UserConfig for cross-device sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quilibrium/quorum-shared",
-  "version": "2.1.0-29",
+  "version": "2.1.0-30",
   "description": "Shared types, hooks, and utilities for Quorum mobile and desktop apps",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -57,6 +57,11 @@ export type UserConfig = {
   profile_image?: string;
   bio?: string;
   isProfilePublic?: boolean;
+  // QNS username set as primary (e.g. "alice" for @alice). camelCase to match
+  // the other app-level config fields; the wire format uses primary_username on
+  // PublicProfile. Synced cross-device so a user's primary username reaches
+  // their other devices.
+  primaryUsername?: string;
   farcasterLink?: FarcasterLink;
   spaceKeys?: {
     spaceId: string;


### PR DESCRIPTION
## What

Adds an optional `primaryUsername?: string` to `UserConfig` and bumps the version to `2.1.0-30`.

## Why

`UserConfig` had no field for the user's primary QNS username, so it could not sync across a user's own devices — it lived only on the device where it was set. The publish/wire machinery (`PublicProfile.primary_username`, the v2 signed payload) already exists; the only missing piece was a synced-config field to carry the value cross-device.

## Notes

- **camelCase** (`primaryUsername`) to match the other app-level config fields (`isProfilePublic`, `showMutedChannels`, etc.); snake_case `primary_username` stays reserved for the `PublicProfile` wire format.
- **Additive + optional** → non-breaking for both desktop and mobile.
- Unblocks the mobile side of the primaryUsername cross-device sync (mobile bumps to `2.1.0-30` and bridges `config.primaryUsername → user` once published).
- Build config (`tsconfig.build.json`) typechecks clean.