### PR TITLE
Role color palette and resolver

### DIFF
--- a/src/primitives/Icon/pickerVocabulary.ts
+++ b/src/primitives/Icon/pickerVocabulary.ts
@@ -23,7 +23,16 @@ export type IconColor =
   | 'green'
   | 'orange'
   | 'yellow'
-  | 'red';
+  | 'red'
+  // Expanded 2026-06-14 (role-color palette): four extra hues so roles have
+  // enough distinct colors. Additive — existing stored values are unaffected.
+  // Both desktop and mobile render these via the `hex` field (getIconColorHex /
+  // getFolderColorHex / getRoleColorHex), so no per-token CSS is required — the
+  // `class` field below is vestigial (getIconColorClass is never called).
+  | 'teal'
+  | 'sky'
+  | 'indigo'
+  | 'pink';
 
 export interface IconOption {
   name: IconName;
@@ -234,7 +243,11 @@ export const ICON_OPTIONS: IconOption[] = [
   { name: 'square', tier: 12, category: 'Shapes' },
 ];
 
-// Icon colors in rainbow order: app-default, blue, purple, fuchsia, green, orange, yellow, red
+// Icon colors in rainbow order: app-default, blue, sky, teal, green, yellow,
+// orange, red, pink, fuchsia, purple, indigo.
+// `yellow` was #ca8a04 (a muddy mustard that reads poorly as a badge fill) —
+// corrected to #eab308 on 2026-06-14. teal/sky/indigo/pink added the same day
+// so the role-color palette has enough distinct hues (see getRoleColorHex).
 export const ICON_COLORS: ColorOption[] = [
   { value: 'default', label: 'Default', class: 'text-subtle', hex: '#9ca3af' },
   { value: 'blue', label: 'Blue', class: 'text-accent-blue', hex: '#3b82f6' },
@@ -242,11 +255,16 @@ export const ICON_COLORS: ColorOption[] = [
   { value: 'fuchsia', label: 'Fuchsia', class: 'text-accent-fuchsia', hex: '#d946ef' },
   { value: 'green', label: 'Green', class: 'text-accent-green', hex: '#22c55e' },
   { value: 'orange', label: 'Orange', class: 'text-accent-orange', hex: '#f97316' },
-  { value: 'yellow', label: 'Yellow', class: 'text-accent-yellow', hex: '#ca8a04' },
+  { value: 'yellow', label: 'Yellow', class: 'text-accent-yellow', hex: '#eab308' },
   { value: 'red', label: 'Red', class: 'text-accent-red', hex: '#ef4444' },
+  { value: 'teal', label: 'Teal', class: 'text-accent-teal', hex: '#14b8a6' },
+  { value: 'sky', label: 'Sky', class: 'text-accent-sky', hex: '#0ea5e9' },
+  { value: 'indigo', label: 'Indigo', class: 'text-accent-indigo', hex: '#6366f1' },
+  { value: 'pink', label: 'Pink', class: 'text-accent-pink', hex: '#ec4899' },
 ];
 
-// Dimmed colors for folder backgrounds — light theme (25% less saturation)
+// Dimmed colors for folder backgrounds — light theme (25% less saturation).
+// New hues (teal/sky/indigo/pink) added 2026-06-14 to mirror ICON_COLORS.
 export const FOLDER_COLORS: ColorOption[] = [
   { value: 'default', label: 'Default', class: 'text-subtle', hex: '#6b7280' },
   { value: 'blue', label: 'Blue', class: 'text-accent-blue', hex: '#5f8eeb' },
@@ -256,6 +274,10 @@ export const FOLDER_COLORS: ColorOption[] = [
   { value: 'orange', label: 'Orange', class: 'text-accent-orange', hex: '#ec814a' },
   { value: 'yellow', label: 'Yellow', class: 'text-accent-yellow', hex: '#d4a017' },
   { value: 'red', label: 'Red', class: 'text-accent-red', hex: '#e7615d' },
+  { value: 'teal', label: 'Teal', class: 'text-accent-teal', hex: '#3fa99a' },
+  { value: 'sky', label: 'Sky', class: 'text-accent-sky', hex: '#3f9fd1' },
+  { value: 'indigo', label: 'Indigo', class: 'text-accent-indigo', hex: '#7376e0' },
+  { value: 'pink', label: 'Pink', class: 'text-accent-pink', hex: '#d36493' },
 ];
 
 // Helper function to get icon color hex value

--- a/src/types/space.ts
+++ b/src/types/space.ts
@@ -17,6 +17,14 @@ export type Role = {
   roleId: string;
   displayName: string;
   roleTag: string;
+  /**
+   * Portable color for the role's badge. Store a named palette token from the
+   * shared icon-color vocabulary (e.g. 'blue', 'green' — see `ROLE_COLORS` /
+   * `IconColor`), NOT a raw platform color and never a CSS variable. Resolve to
+   * a render hex with `getRoleColorHex()`, which also tolerates legacy values
+   * (raw hex from old mobile roles, the legacy desktop 'rgb(var(--success))').
+   * Kept as `string` for wire-compat; treat new writes as a token.
+   */
   color: string;
   members: string[];
   permissions: Permission[];

--- a/src/utils/roleUtils.test.ts
+++ b/src/utils/roleUtils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { toggleRolePermission, setRolePermissions } from './roleUtils';
+import {
+  toggleRolePermission,
+  setRolePermissions,
+  getRoleColorHex,
+  getDefaultRoleColor,
+  ROLE_COLORS,
+} from './roleUtils';
+import { ICON_COLORS, getIconColorHex } from '../primitives/Icon/pickerVocabulary';
 import type { Role } from '../types';
 
 const baseRole: Role = {
@@ -50,5 +57,67 @@ describe('setRolePermissions', () => {
     const snapshot = [...role.permissions];
     setRolePermissions(role, ['message:pin']);
     expect(role.permissions).toEqual(snapshot);
+  });
+});
+
+describe('ROLE_COLORS', () => {
+  it('excludes the grey default and exposes only named hues', () => {
+    expect(ROLE_COLORS.some((c) => c.value === 'default')).toBe(false);
+    expect(ROLE_COLORS.length).toBe(ICON_COLORS.length - 1);
+  });
+
+  it('every entry is a valid hex', () => {
+    for (const c of ROLE_COLORS) {
+      expect(c.hex).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+});
+
+describe('getRoleColorHex', () => {
+  it('resolves a named palette token to its hex', () => {
+    expect(getRoleColorHex('green')).toBe(getIconColorHex('green'));
+    expect(getRoleColorHex('blue')).toBe(getIconColorHex('blue'));
+  });
+
+  it('passes through an already-valid hex (legacy mobile roles)', () => {
+    expect(getRoleColorHex('#22c55e')).toBe('#22c55e');
+    expect(getRoleColorHex('#abc')).toBe('#abc');
+  });
+
+  it('maps the legacy desktop CSS-var string to the green hex', () => {
+    expect(getRoleColorHex('rgb(var(--success))')).toBe(getIconColorHex('green'));
+  });
+
+  it('falls back for unknown / unparseable values', () => {
+    const fallback = ROLE_COLORS[0].hex;
+    expect(getRoleColorHex('not-a-color')).toBe(fallback);
+    expect(getRoleColorHex('rgb(var(--whatever))')).toBe(fallback);
+    expect(getRoleColorHex('')).toBe(fallback);
+  });
+
+  it('falls back for null / undefined without throwing', () => {
+    const fallback = ROLE_COLORS[0].hex;
+    expect(getRoleColorHex(undefined)).toBe(fallback);
+    expect(getRoleColorHex(null)).toBe(fallback);
+  });
+});
+
+describe('getDefaultRoleColor', () => {
+  it('returns a palette token', () => {
+    const token = getDefaultRoleColor('role-abc');
+    expect(ROLE_COLORS.some((c) => c.value === token)).toBe(true);
+  });
+
+  it('is deterministic for the same seed', () => {
+    expect(getDefaultRoleColor('role-abc')).toBe(getDefaultRoleColor('role-abc'));
+  });
+
+  it('handles an empty seed without throwing', () => {
+    const token = getDefaultRoleColor('');
+    expect(ROLE_COLORS.some((c) => c.value === token)).toBe(true);
+  });
+
+  it('the chosen token resolves to a valid hex via getRoleColorHex', () => {
+    expect(getRoleColorHex(getDefaultRoleColor('seed-xyz'))).toMatch(/^#[0-9a-fA-F]{6}$/);
   });
 });

--- a/src/utils/roleUtils.ts
+++ b/src/utils/roleUtils.ts
@@ -1,4 +1,85 @@
 import type { Permission, Role } from '../types';
+import { ICON_COLORS, getIconColorHex, type IconColor } from '../primitives/Icon/pickerVocabulary';
+
+/**
+ * Role color palette + resolver.
+ *
+ * `Role.color` is part of the synced space manifest, so it MUST be a portable,
+ * platform-independent value — a named palette token (e.g. 'blue'), resolved to
+ * a hex at render time. (React Native cannot resolve CSS variables, so a web
+ * value like 'rgb(var(--success))' renders as an invalid color there.)
+ *
+ * Roles draw from the SAME named-color vocabulary as the icon/folder picker
+ * (ICON_COLORS) so the app has one color story. We exclude 'default' (grey) —
+ * a role wants a real hue. `getRoleColorHex` tolerates legacy values already in
+ * the wild (raw hex from old mobile clients, the legacy desktop CSS-var string)
+ * so historical roles keep rendering.
+ */
+
+/** Role-assignable palette: every named hue except the grey `default`. */
+export const ROLE_COLORS: { value: IconColor; hex: string }[] = ICON_COLORS
+  .filter((c) => c.value !== 'default')
+  .map((c) => ({ value: c.value, hex: c.hex }));
+
+/** Fallback when a role color can't be resolved (first palette hue). */
+const ROLE_COLOR_FALLBACK = ROLE_COLORS[0]?.hex ?? '#3b82f6';
+
+/**
+ * The single legacy CSS-variable string desktop historically wrote into
+ * `Role.color` (the hardcoded default before the palette existed). It resolves
+ * in a browser but not in React Native — map it to the green hue so old roles
+ * stay green everywhere instead of rendering invisibly.
+ */
+const LEGACY_CSS_VAR_TO_TOKEN: Record<string, IconColor> = {
+  'rgb(var(--success))': 'green',
+};
+
+const HEX_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+/**
+ * Resolve a stored `Role.color` to a render-safe hex, tolerating every format
+ * seen in the wild:
+ *  - a named palette token ('blue', 'green', …)  → its hex
+ *  - an already-valid hex ('#22c55e', mobile legacy) → passthrough
+ *  - the legacy desktop CSS-var ('rgb(var(--success))') → the green hex
+ *  - anything else (empty / unparseable)         → the palette fallback
+ *
+ * Never throws. Safe to call on any string from a manifest.
+ */
+export function getRoleColorHex(color: string | undefined | null): string {
+  if (!color) return ROLE_COLOR_FALLBACK;
+
+  // Named palette token (the canonical, going-forward format).
+  const token = ROLE_COLORS.find((c) => c.value === color);
+  if (token) return token.hex;
+
+  // Already a portable hex (old mobile roles stored raw hex).
+  if (HEX_RE.test(color)) return color;
+
+  // Known legacy CSS-variable string from old desktop roles.
+  const legacyToken = LEGACY_CSS_VAR_TO_TOKEN[color];
+  if (legacyToken) return getIconColorHex(legacyToken);
+
+  // Unknown / unparseable — don't render an invalid color.
+  return ROLE_COLOR_FALLBACK;
+}
+
+/**
+ * Pick a stable, distinct default color token for a new role from a seed
+ * (use the roleId). Deterministic so the same role resolves to the same color
+ * on every device without storing a random value. DJB2 hash, mirroring
+ * getColorFromDisplayName in avatar.ts.
+ */
+export function getDefaultRoleColor(seed: string): IconColor {
+  if (!seed || ROLE_COLORS.length === 0) {
+    return ROLE_COLORS[0]?.value ?? 'blue';
+  }
+  let hash = 5381;
+  for (let i = 0; i < seed.length; i++) {
+    hash = ((hash << 5) + hash) + seed.charCodeAt(i); // hash * 33 + c
+  }
+  return ROLE_COLORS[(hash >>> 0) % ROLE_COLORS.length].value;
+}
 
 /**
  * Add or remove a permission from a role.


### PR DESCRIPTION
Roles now store `color` as a portable named token (the same vocabulary the icon/folder picker uses), resolved to a hex at render time. This fixes role colors not rendering cross-platform: desktop historically wrote a web CSS-variable string (`rgb(var(--success))`) into `Role.color`, which React Native cannot parse — so a desktop-assigned role's pill rendered invisibly on mobile.

## Changes
- Extend `ICON_COLORS` / `FOLDER_COLORS` with **teal, sky, indigo, pink** so roles have enough distinct hues, and correct the muddy yellow (`#ca8a04` → `#eab308`).
- Add `ROLE_COLORS` (the named hues minus the grey `default`).
- Add `getRoleColorHex(color)` — resolves a token / valid hex / the legacy `rgb(var(--success))` string / falls back for anything unparseable. Never throws.
- Add `getDefaultRoleColor(seed)` — deterministic token from a seed (use the roleId), so a new role gets a stable, distinct color without a picker, and the value syncs.
- Document the `Role.color` portable-token contract.
- Tests for the resolver and default picker.

## Safety
- **No version bump** — rides the next publish (currently `2.1.0-30`).
- **Additive only**: no removals, renames, or signature changes.
- Mobile references none of these symbols today (audited), so a future mobile bump cannot break; new colors simply won't surface in mobile's picker until mobile opts in.
- Desktop renders icon/folder/role colors via the `hex` field everywhere (`getIconColorClass` is never called), so the new tokens need no per-token CSS.

## Verification
- typecheck: clean (no new errors over baseline).
- tests: 17/17 pass in `roleUtils.test.ts` (incl. token→hex, hex passthrough, legacy css-var→green, garbage→fallback, null/undefined no-throw, deterministic default).
- build: succeeds; confirmed `ROLE_COLORS`/`getRoleColorHex`/`getDefaultRoleColor` + the widened `IconColor` union + new hexes are present in the built dist.