### PR TITLE
Role tag/name uniqueness helpers

### DIFF
--- a/src/utils/roleUtils.test.ts
+++ b/src/utils/roleUtils.test.ts
@@ -5,6 +5,9 @@ import {
   getRoleColorHex,
   getDefaultRoleColor,
   ROLE_COLORS,
+  findRoleConflict,
+  isRoleIdentityAvailable,
+  getUniqueRoleDefaults,
 } from './roleUtils';
 import { ICON_COLORS, getIconColorHex } from '../primitives/Icon/pickerVocabulary';
 import type { Role } from '../types';
@@ -119,5 +122,72 @@ describe('getDefaultRoleColor', () => {
 
   it('the chosen token resolves to a valid hex via getRoleColorHex', () => {
     expect(getRoleColorHex(getDefaultRoleColor('seed-xyz'))).toMatch(/^#[0-9a-fA-F]{6}$/);
+  });
+});
+
+const rolesFixture: Role[] = [
+  { ...baseRole, roleId: 'r1', displayName: 'Mod', roleTag: 'mod' },
+  { ...baseRole, roleId: 'r2', displayName: 'Admin', roleTag: 'admin' },
+];
+
+describe('findRoleConflict', () => {
+  it('returns null when tag and name are both unique', () => {
+    expect(findRoleConflict(rolesFixture, { roleTag: 'helper', displayName: 'Helper' })).toBeNull();
+  });
+
+  it('detects a duplicate tag (case-insensitive, trimmed)', () => {
+    const c = findRoleConflict(rolesFixture, { roleTag: ' MOD ' });
+    expect(c?.field).toBe('roleTag');
+    expect(c?.role.roleId).toBe('r1');
+  });
+
+  it('detects a duplicate name (case-insensitive)', () => {
+    const c = findRoleConflict(rolesFixture, { displayName: 'admin' });
+    expect(c?.field).toBe('displayName');
+    expect(c?.role.roleId).toBe('r2');
+  });
+
+  it('reports tag before name when both collide', () => {
+    expect(findRoleConflict(rolesFixture, { roleTag: 'mod', displayName: 'Admin' })?.field).toBe('roleTag');
+  });
+
+  it('excludes the role being edited (no self-conflict)', () => {
+    expect(findRoleConflict(rolesFixture, { roleTag: 'mod', displayName: 'Mod' }, 'r1')).toBeNull();
+  });
+
+  it('still flags a collision with a DIFFERENT role when editing', () => {
+    expect(findRoleConflict(rolesFixture, { roleTag: 'admin' }, 'r1')?.role.roleId).toBe('r2');
+  });
+});
+
+describe('isRoleIdentityAvailable', () => {
+  it('is the boolean inverse of findRoleConflict', () => {
+    expect(isRoleIdentityAvailable(rolesFixture, { roleTag: 'mod' })).toBe(false);
+    expect(isRoleIdentityAvailable(rolesFixture, { roleTag: 'helper', displayName: 'Helper' })).toBe(true);
+  });
+});
+
+describe('getUniqueRoleDefaults', () => {
+  it('returns the unsuffixed base when free', () => {
+    expect(getUniqueRoleDefaults([])).toEqual({ displayName: 'New Role', roleTag: 'newrole' });
+  });
+
+  it('suffixes when the base name/tag is taken', () => {
+    const roles: Role[] = [{ ...baseRole, roleId: 'a', displayName: 'New Role', roleTag: 'newrole' }];
+    expect(getUniqueRoleDefaults(roles)).toEqual({ displayName: 'New Role 2', roleTag: 'newrole-2' });
+  });
+
+  it('skips occupied suffixes (3 in a row)', () => {
+    const roles: Role[] = [
+      { ...baseRole, roleId: 'a', displayName: 'New Role', roleTag: 'newrole' },
+      { ...baseRole, roleId: 'b', displayName: 'New Role 2', roleTag: 'newrole-2' },
+    ];
+    expect(getUniqueRoleDefaults(roles)).toEqual({ displayName: 'New Role 3', roleTag: 'newrole-3' });
+  });
+
+  it('the produced defaults are actually available', () => {
+    const roles: Role[] = [{ ...baseRole, roleId: 'a', displayName: 'New Role', roleTag: 'newrole' }];
+    const d = getUniqueRoleDefaults(roles);
+    expect(isRoleIdentityAvailable(roles, d)).toBe(true);
   });
 });

--- a/src/utils/roleUtils.ts
+++ b/src/utils/roleUtils.ts
@@ -103,3 +103,83 @@ export function toggleRolePermission(role: Role, permission: Permission): Role {
 export function setRolePermissions(role: Role, permissions: Permission[]): Role {
   return { ...role, permissions };
 }
+
+// ============================================
+// ROLE TAG / NAME UNIQUENESS
+// ============================================
+//
+// A role has both a `roleTag` (used to @mention the role) and a `displayName`.
+// Neither should collide with another role in the same space. Matching is
+// case-insensitive and trims surrounding whitespace, so "Mod" and " mod " are
+// considered the same. Both clients should enforce this identically.
+
+/** Which field of a candidate role collides with an existing role. */
+export type RoleConflictField = 'roleTag' | 'displayName';
+
+const normalizeRoleValue = (value: string): string => value.trim().toLowerCase();
+
+/**
+ * Find the first existing role whose tag or name collides with the candidate.
+ * Returns `null` if the candidate is unique.
+ *
+ * @param roles       all roles currently in the space
+ * @param candidate   the tag/name being created or edited
+ * @param excludeRoleId  when editing, the role being edited (so it doesn't
+ *                       conflict with itself)
+ */
+export function findRoleConflict(
+  roles: Role[],
+  candidate: { roleTag?: string; displayName?: string },
+  excludeRoleId?: string,
+): { field: RoleConflictField; role: Role } | null {
+  const tag = candidate.roleTag != null ? normalizeRoleValue(candidate.roleTag) : undefined;
+  const name = candidate.displayName != null ? normalizeRoleValue(candidate.displayName) : undefined;
+
+  for (const role of roles) {
+    if (role.roleId === excludeRoleId) continue;
+    if (tag && normalizeRoleValue(role.roleTag) === tag) {
+      return { field: 'roleTag', role };
+    }
+    if (name && normalizeRoleValue(role.displayName) === name) {
+      return { field: 'displayName', role };
+    }
+  }
+  return null;
+}
+
+/** True if the candidate tag/name does not collide with any existing role. */
+export function isRoleIdentityAvailable(
+  roles: Role[],
+  candidate: { roleTag?: string; displayName?: string },
+  excludeRoleId?: string,
+): boolean {
+  return findRoleConflict(roles, candidate, excludeRoleId) === null;
+}
+
+/**
+ * Produce a unique default displayName + roleTag for a NEW role, suffixing a
+ * number when the base is already taken: "New Role", "New Role 2", … and
+ * "newrole", "newrole-2", …. Avoids creating duplicate-named roles when the
+ * user repeatedly hits an "add role" button (there is no per-role save gate).
+ */
+export function getUniqueRoleDefaults(
+  roles: Role[],
+  baseName = 'New Role',
+  baseTag = 'newrole',
+): { displayName: string; roleTag: string } {
+  let n = 1;
+  // n === 1 is the unsuffixed base; 2+ append the number.
+  // Loop until both the name and the tag are free at the same suffix.
+  // (Bounded by roles.length + 1 in practice; the guard caps pathological input.)
+  while (n < roles.length + 2) {
+    const displayName = n === 1 ? baseName : `${baseName} ${n}`;
+    const roleTag = n === 1 ? baseTag : `${baseTag}-${n}`;
+    if (isRoleIdentityAvailable(roles, { roleTag, displayName })) {
+      return { displayName, roleTag };
+    }
+    n++;
+  }
+  // Fallback (shouldn't happen): force-unique with the count.
+  const suffix = roles.length + 1;
+  return { displayName: `${baseName} ${suffix}`, roleTag: `${baseTag}-${suffix}` };
+}


### PR DESCRIPTION
Roles have a `roleTag` (used to @mention the role) and a `displayName`. Neither should collide with another role in the same space — but currently neither client enforces this (you can spam an 'add role' button and create many identical roles).

## Adds (pure helpers, additive)
- **`findRoleConflict(roles, candidate, excludeRoleId?)`** — returns the first existing role whose tag or name collides with the candidate (case-insensitive, trimmed), or null. `excludeRoleId` skips the role being edited so it doesn't conflict with itself.
- **`isRoleIdentityAvailable(...)`** — boolean inverse, for guard checks.
- **`getUniqueRoleDefaults(roles, baseName?, baseTag?)`** — auto-numbered defaults ('New Role' / 'New Role 2' / …; 'newrole' / 'newrole-2' / …) so repeatedly adding roles never produces duplicates.

## Consumers
Mobile wires these into its role create (auto-numbered defaults) and edit (block + inline error on collision) paths now. Desktop can adopt the same helpers later (it also lacks the check today).

## Safety
- **No version bump** — rides the next publish.
- Additive only; no removals/renames/signature changes.

## Verification
- tests: 28/28 pass in roleUtils.test.ts (11 new: tag/name dup detection, case-insensitivity, exclude-self on edit, auto-numbered defaults).
- typecheck clean; build confirmed the helpers are in the dist.