### PR TITLE
Run build automatically before publish (prepublishOnly hook)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "prepublishOnly": "npm run build",
     "build": "tsup && tsc --project tsconfig.build.json",
     "dev": "tsup --watch",
     "lint": "eslint src --ext .ts,.tsx",


### PR DESCRIPTION
## Problem
`npm publish` does not run `build` (no `prepublishOnly`/`prepare`/`prepack` hook), so it ships whatever `dist/` happens to be on disk. If `dist/` wasn't rebuilt after merging, a **stale build reaches the registry while the version still bumps**.

This just bit us: published `2.1.0-30` ships a `dist/` missing recently-merged symbols (role color resolver, role uniqueness helpers, `primaryUsername`) even though its `src/` has them. Same class of issue as `2.1.0-26`.

## Fix
One line: `"prepublishOnly": "npm run build"`. Now publish always rebuilds `dist/` from current source first, so a stale dist can't reach the registry.

## Notes
- **No version bump** — only affects the publish workflow, not runtime/types output.
- Does not fix the already-published `2.1.0-30` (that needs a manual rebuild + re-publish); this prevents recurrence.