### PR TITLE
feat(types): add space isMuted + per-space blockedUsers to UserConfig

### DIFF
--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -26,6 +26,11 @@ export type NotificationSettings = {
   mentions?: boolean;
   replies?: boolean;
   all?: boolean;
+  // When true, ALL notifications for this space are suppressed (space-level mute).
+  // Takes precedence over per-channel mute. Desktop already writes this field;
+  // declaring it here lets both apps read/write it typed and keeps space-mute in
+  // sync across devices via the UserConfig blob.
+  isMuted?: boolean;
 };
 
 export type UserNote = {
@@ -93,6 +98,13 @@ export type UserConfig = {
   hideMutedSpacesFromSidebar?: boolean;
   favoriteDMs?: string[];
   mutedConversations?: string[];
+  // Personal "block user": addresses whose messages the viewer hides from their
+  // own stream, scoped per space. This is a viewer-side hide (no moderation
+  // effect, no permission needed) — distinct from the role-gated moderation mute
+  // (MuteMessage). Synced cross-device via the UserConfig blob.
+  blockedUsers?: {
+    [spaceId: string]: string[];
+  };
   spaceTagId?: string;
   lastBroadcastSpaceTag?: {
     letters: string;

--- a/src/utils/blockUtils.ts
+++ b/src/utils/blockUtils.ts
@@ -1,0 +1,33 @@
+/**
+ * blockUtils — pure helpers for the personal "block user" feature.
+ *
+ * Personal block is a VIEWER-SIDE hide: the viewer chooses to hide a user's
+ * messages from their own stream, scoped per space. It needs no permission and
+ * has no effect for anyone else — distinct from the role-gated moderation mute
+ * (which broadcasts a MuteMessage and silences a user for everyone).
+ *
+ * State lives on `UserConfig.blockedUsers` ({ [spaceId]: address[] }) so it syncs
+ * across the viewer's devices via the config blob.
+ */
+
+import type { UserConfig } from '../types/user';
+
+/**
+ * Is `userAddress` blocked by the viewer in `spaceId`?
+ * Pure lookup over `UserConfig.blockedUsers`; safe with undefined input.
+ */
+export function isUserBlocked(
+  userAddress: string,
+  spaceId: string,
+  blockedUsers?: UserConfig['blockedUsers']
+): boolean {
+  return blockedUsers?.[spaceId]?.includes(userAddress) ?? false;
+}
+
+/** All addresses the viewer has blocked in `spaceId` (empty array if none). */
+export function getBlockedUsersForSpace(
+  spaceId: string,
+  blockedUsers?: UserConfig['blockedUsers']
+): string[] {
+  return blockedUsers?.[spaceId] ?? [];
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -24,6 +24,7 @@ export * from './avatar';
 export * from './canonicalize';
 export * from './clipboard';
 export * from './notificationSettingsUtils';
+export * from './blockUtils';
 export * from './inviteDomain';
 export * from './environmentDomains';
 export * from './youtubeUtils';


### PR DESCRIPTION
Additive `UserConfig` fields enabling cross-device mute/block sync (consumed by mobile next; desktop can adopt later via its symlink).

## Changes (all additive — existing consumers unaffected)
- **`NotificationSettings.isMuted?: boolean`** — space-level notification mute. Desktop already writes this field; declaring it in the shared type lets both apps read/write it typed and keeps space-mute in sync across devices via the `UserConfig` blob.
- **`UserConfig.blockedUsers?: { [spaceId]: string[] }`** — per-space personal "block user" (viewer-side message hide; no permission, no moderation effect). Distinct from the role-gated moderation mute (`MuteMessage`).
- **`blockUtils`** — pure helpers `isUserBlocked(userAddress, spaceId, blockedUsers)` and `getBlockedUsersForSpace(spaceId, blockedUsers)`, exported from the utils barrel.

## Safety
- Purely additive (13 source lines, nothing changed or removed).
- `npm run build` (tsup + tsc) passes; new types confirmed in emitted `dist` declarations.