### PR TITLE
Add Qm-aware formatAddress to shared formatting utils

### DIFF
--- a/src/utils/formatting.test.ts
+++ b/src/utils/formatting.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { formatAddress } from './formatting';
+
+// Real CIDv0 Quilibrium address (46 chars: "Qm" + 44 base58).
+const ADDR = 'QmQuCGpEgVKpYZKYuFu2J49zHXnA8vZtEqHMtpB4imXST1';
+
+describe('formatAddress', () => {
+  describe('Qm-aware slicing', () => {
+    it('keeps Qm visible and counts start AFTER the prefix (default 6/6)', () => {
+      // "Qm" + 6 meaningful + "…" + 6 = true 12-char anchor.
+      expect(formatAddress(ADDR)).toBe('QmQuCGpE…imXST1');
+    });
+
+    it('honors custom start/end', () => {
+      expect(formatAddress(ADDR, 4, 4)).toBe('QmQuCG…XST1');
+      expect(formatAddress(ADDR, 10, 8)).toBe('QmQuCGpEgVKp…B4imXST1');
+    });
+
+    it('uses the Unicode ellipsis (…), not ASCII dots', () => {
+      expect(formatAddress(ADDR)).toContain('…');
+      expect(formatAddress(ADDR)).not.toContain('...');
+    });
+  });
+
+  describe('passthrough cases', () => {
+    it('returns @usernames verbatim', () => {
+      expect(formatAddress('@alice')).toBe('@alice');
+    });
+
+    it('returns empty string for empty/null/undefined', () => {
+      expect(formatAddress('')).toBe('');
+      expect(formatAddress(null)).toBe('');
+      expect(formatAddress(undefined)).toBe('');
+    });
+
+    it('returns short addresses as-is (nothing meaningful to truncate)', () => {
+      expect(formatAddress('Qm123456')).toBe('Qm123456');
+    });
+  });
+
+  describe('non-Qm addresses', () => {
+    it('falls back to plain start/end slicing when there is no Qm prefix', () => {
+      expect(formatAddress('bafy1234567890abcdefghij')).toBe('bafy12…efghij');
+    });
+  });
+});

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -13,6 +13,42 @@ export function truncateText(text: string, maxLength: number): string {
 }
 
 /**
+ * Truncate a Quilibrium address for display.
+ *
+ * Every Quilibrium address is a CIDv0 ("Qm" + 44 base58 chars); the "Qm"
+ * prefix is a constant multihash header (0x12 0x20) and carries ZERO entropy.
+ * We keep "Qm" visible (brand recognizability) but do NOT spend the `start`
+ * budget on it — `start` counts MEANINGFUL chars after the prefix. This yields
+ * a true `start + end`-char discriminating anchor, which matters for resisting
+ * address-grinding/impersonation. Defaults (6/6) give a 12-char anchor.
+ *
+ * Truncation is a disambiguation + anti-grind label, NOT identity proof —
+ * surface the full address for real trust decisions.
+ *
+ * @param address  Full address (or @username, returned verbatim).
+ * @param start    Meaningful leading chars to show AFTER the Qm prefix. Default 6.
+ * @param end      Trailing chars to show. Default 6.
+ */
+export function formatAddress(
+  address: string | undefined | null,
+  start = 6,
+  end = 6,
+): string {
+  if (!address) return '';
+  if (address.startsWith('@')) return address; // username passthrough
+
+  // 'Qm' = constant CIDv0 multihash prefix → zero entropy. Keep it visible,
+  // but don't count it toward `start`.
+  const hasQm = address.startsWith('Qm');
+  const head = hasQm ? 2 : 0;
+
+  // If too short to truncate meaningfully, return as-is.
+  if (address.length <= head + start + end + 1) return address;
+
+  return `${address.slice(0, head + start)}…${address.slice(-end)}`;
+}
+
+/**
  * Format file size (e.g., "1.5 MB")
  */
 export function formatFileSize(bytes: number): string {


### PR DESCRIPTION
Adds one canonical address-truncation helper, `formatAddress(address, start = 6, end = 6)`, to `src/utils/formatting.ts`.

## What it does

- Keeps the constant `Qm` CIDv0 prefix visible (brand) but excludes it from the `start` budget, so `start`/`end` count meaningful entropy chars after the prefix.
- Defaults (6/6) produce a true 12-char discriminating anchor, e.g. `QmQuCGpE…imXST1`.
- Passes through `@usernames`, empty/null/undefined (→ `''`), and addresses too short to truncate.
- Non-`Qm` addresses fall back to plain start/end slicing.
- Uses the Unicode ellipsis (`…`) to match the existing `truncateText` house style.

## Tests

New `src/utils/formatting.test.ts` (7 tests): Qm-aware slicing, custom start/end, ellipsis style, and all passthrough cases. Expected values are computed from the function against a real CIDv0 address.

## Notes

- Additive only — no existing exports changed or removed. Auto-exported via the `formatting` → `utils` → root barrel chain.
- `yarn build` passes (ESM + CJS + native bundles).
- Version bump and publish are intentionally left out of this PR.