### PR TITLE
Add shared image compression config + orchestration

### DIFF
--- a/src/utils/imageConfig.ts
+++ b/src/utils/imageConfig.ts
@@ -1,0 +1,195 @@
+/**
+ * Shared image-processing configuration (platform-agnostic).
+ *
+ * This module is intentionally PURE: no DOM, no native, no platform imports.
+ * It is the single source of truth for image limits/targets across desktop
+ * (compressorjs) and mobile (expo-image-manipulator). Keep it import-free so it
+ * builds cleanly for both the web and React Native bundles.
+ *
+ * Canonical dimensions decided 2026-06-24 (desktop + mobile consistency):
+ *   avatar 256, space icon 256, emoji 96, sticker 512 (longest axis),
+ *   space banner 1600x900 (16:9, cropped at render), message attachment 1200.
+ */
+
+/**
+ * File size limits (input limits before compression).
+ */
+export const FILE_SIZE_LIMITS = {
+  // Input limits - what users can upload
+  MAX_INPUT_SIZE: 25 * 1024 * 1024, // 25MB for static images (will be compressed)
+  MAX_GIF_SIZE: 2 * 1024 * 1024, // 2MB hard limit for GIFs (storage efficiency)
+  MAX_EMOJI_INPUT_SIZE: 5 * 1024 * 1024, // 5MB for emojis
+
+  // Processing thresholds
+  GIF_THUMBNAIL_THRESHOLD: 500 * 1024, // 500KB - show thumbnail for GIFs above this
+  MAX_STICKER_GIF_SIZE: 750 * 1024, // 750KB - animated sticker GIFs (displayed at 300px max)
+  MAX_EMOJI_GIF_SIZE: 100 * 1024, // 100KB - animated emoji GIFs (displayed at 24x24px)
+
+  // Legacy limits (for reference)
+  LEGACY_MESSAGE_LIMIT: 2 * 1024 * 1024, // 2MB
+  LEGACY_AVATAR_LIMIT: 2 * 1024 * 1024, // 2MB
+  LEGACY_SPACE_ASSET_LIMIT: 1 * 1024 * 1024, // 1MB
+  LEGACY_EMOJI_LIMIT: 256 * 1024, // 256KB
+} as const;
+
+/**
+ * Image processing configuration for a single use case.
+ */
+export interface ImageConfig {
+  // Output dimensions
+  maxWidth: number;
+  maxHeight: number;
+  quality: number;
+
+  // Aspect ratio handling
+  cropToFit?: boolean;
+  maintainAspectRatio?: boolean;
+
+  // Compression settings
+  skipCompressionThreshold: number;
+
+  // GIF handling
+  gifSizeLimit?: number | null; // null means no GIFs allowed
+  preserveGifAnimation?: boolean;
+  gifMaxDisplayWidth?: number; // CSS max-width for GIF display (300px)
+
+  // Thumbnail generation (for dual-image scenarios)
+  thumbnailConfig?: {
+    maxWidth: number;
+    maxHeight: number;
+    quality: number;
+    threshold: number; // Generate thumbnail if original is larger than this
+  };
+}
+
+/**
+ * Options accepted by a platform compressor implementation.
+ * All primitive — safe to share across platforms.
+ */
+export interface ImageProcessingOptions {
+  /** Maximum width in pixels */
+  maxWidth?: number;
+  /** Maximum height in pixels */
+  maxHeight?: number;
+  /** Compression quality (0-1) */
+  quality?: number;
+  /** Whether to maintain aspect ratio when resizing */
+  maintainAspectRatio?: boolean;
+  /** Whether to crop to exact dimensions or fit within bounds */
+  cropToFit?: boolean;
+  /** Skip compression for files smaller than this size (bytes) */
+  skipCompressionThreshold?: number;
+  /** Force compression of GIFs (they are normally skipped to preserve animation) */
+  forceGifCompression?: boolean;
+}
+
+/**
+ * Per-surface image configurations.
+ *
+ * Dimensions are sized as ~display-size x peak-device-pixel-ratio, capped for
+ * storage, so one source is crisp on the densest mobile screen and on desktop
+ * retina.
+ */
+export const IMAGE_CONFIGS = {
+  /**
+   * User avatars - square crop, no GIFs.
+   * 256x256 source. Display ~40-82px; 82 x 3 DPR ~= 246 -> 256.
+   */
+  avatar: {
+    maxWidth: 256,
+    maxHeight: 256,
+    quality: 0.8,
+    cropToFit: true,
+    skipCompressionThreshold: 50 * 1024, // 50KB
+    gifSizeLimit: null, // No GIFs allowed
+  } as ImageConfig,
+
+  /**
+   * Space icons - square crop, no GIFs. Same display role as avatar.
+   * 256x256 source.
+   */
+  spaceIcon: {
+    maxWidth: 256,
+    maxHeight: 256,
+    quality: 0.8,
+    cropToFit: true,
+    skipCompressionThreshold: 50 * 1024, // 50KB
+    gifSizeLimit: null, // No GIFs allowed
+  } as ImageConfig,
+
+  /**
+   * Space banners - 16:9, no GIFs. Store a clean 16:9 source and let each
+   * surface cover-crop at render (channel-list strip, mobile header, future
+   * discover hero). 1600x900.
+   */
+  spaceBanner: {
+    maxWidth: 1600,
+    maxHeight: 900,
+    quality: 0.8,
+    maintainAspectRatio: true, // no hard crop at upload; surfaces crop at render
+    skipCompressionThreshold: 100 * 1024, // 100KB
+    gifSizeLimit: null, // No GIFs allowed
+  } as ImageConfig,
+
+  /**
+   * Message attachments - smart thumbnail system for large images/GIFs.
+   * All GIFs constrained to 300px max width via CSS.
+   */
+  messageAttachment: {
+    maxWidth: 1200,
+    maxHeight: 1200,
+    quality: 0.8,
+    maintainAspectRatio: true,
+    skipCompressionThreshold: 100 * 1024, // 100KB
+    gifSizeLimit: FILE_SIZE_LIMITS.MAX_GIF_SIZE,
+    preserveGifAnimation: true,
+    gifMaxDisplayWidth: 300, // All GIFs constrained to 300px via CSS
+    thumbnailConfig: {
+      maxWidth: 300,
+      maxHeight: 300,
+      quality: 0.8,
+      threshold: 300, // Generate thumbnail for images > 300px
+    },
+  } as ImageConfig,
+
+  /**
+   * Custom emojis - tiny display, preserve small GIFs.
+   * 96x96 source. Display 24px; 24 x 3 DPR = 72 -> 96 for picker preview headroom.
+   */
+  emoji: {
+    maxWidth: 96,
+    maxHeight: 96,
+    quality: 0.8,
+    cropToFit: true,
+    skipCompressionThreshold: 50 * 1024, // 50KB
+    gifSizeLimit: FILE_SIZE_LIMITS.MAX_EMOJI_GIF_SIZE,
+    preserveGifAnimation: true,
+  } as ImageConfig,
+
+  /**
+   * Custom stickers - longest-axis cap to preserve aspect, displayed at 300px.
+   * 512 longest axis.
+   */
+  sticker: {
+    maxWidth: 512,
+    maxHeight: 512,
+    quality: 0.8,
+    maintainAspectRatio: true,
+    skipCompressionThreshold: 100 * 1024, // 100KB
+    gifSizeLimit: FILE_SIZE_LIMITS.MAX_STICKER_GIF_SIZE,
+    preserveGifAnimation: true,
+    gifMaxDisplayWidth: 300, // Display at 300px max width
+  } as ImageConfig,
+} as const;
+
+/**
+ * Type-safe keys for image configurations.
+ */
+export type ImageConfigType = keyof typeof IMAGE_CONFIGS;
+
+/**
+ * Get configuration for a specific image type.
+ */
+export const getImageConfig = (type: ImageConfigType): ImageConfig => {
+  return IMAGE_CONFIGS[type];
+};

--- a/src/utils/imageConfig.ts
+++ b/src/utils/imageConfig.ts
@@ -118,9 +118,12 @@ export const IMAGE_CONFIGS = {
   } as ImageConfig,
 
   /**
-   * Space banners - 16:9, no GIFs. Store a clean 16:9 source and let each
-   * surface cover-crop at render (channel-list strip, mobile header, future
-   * discover hero). 1600x900.
+   * Space banners - no GIFs. 1600x900 is a BOUNDING BOX (maintainAspectRatio),
+   * not a target shape: the user's image keeps its aspect, capped to fit. Each
+   * surface cover-crops at render. Banners display as a wide ~2:1 strip
+   * (desktop channel-list header ~260-300x132; mobile header full-width x180;
+   * future discover hero), so the upload UI hints "optimal ratio 2:1". The box
+   * is sized for the largest consumer (full-width mobile/discover at ~3x DPR).
    */
   spaceBanner: {
     maxWidth: 1600,

--- a/src/utils/imageOrchestration.test.ts
+++ b/src/utils/imageOrchestration.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ImageInput,
+  ImagePlatform,
+  ImageProcessingError,
+  processImageWithConfig,
+  processAttachmentWithConfig,
+  shouldGenerateGifThumbnail,
+} from './imageOrchestration';
+import { FILE_SIZE_LIMITS, IMAGE_CONFIGS } from './imageConfig';
+
+type Result = { tag: string };
+
+/** Build a mock platform that records which path was taken. */
+function mockPlatform(
+  overrides: Partial<ImagePlatform<ImageInput, Result>> = {},
+): ImagePlatform<ImageInput, Result> {
+  return {
+    compress: vi.fn(async () => ({ tag: 'compress' })),
+    passthroughGif: vi.fn(async () => ({ tag: 'gif' })),
+    getDimensions: vi.fn(async () => ({ width: 100, height: 100 })),
+    ...overrides,
+  };
+}
+
+const file = (size: number, type = 'image/png'): ImageInput => ({ size, type });
+
+describe('processImageWithConfig', () => {
+  it('routes static images through compress', async () => {
+    const platform = mockPlatform();
+    const r = await processImageWithConfig(file(1000), 'avatar', platform);
+    expect(r).toEqual({ tag: 'compress' });
+    expect(platform.compress).toHaveBeenCalledOnce();
+    expect(platform.passthroughGif).not.toHaveBeenCalled();
+  });
+
+  it('routes GIFs through passthroughGif', async () => {
+    const platform = mockPlatform();
+    const r = await processImageWithConfig(file(1000, 'image/gif'), 'sticker', platform);
+    expect(r).toEqual({ tag: 'gif' });
+    expect(platform.passthroughGif).toHaveBeenCalledOnce();
+    expect(platform.compress).not.toHaveBeenCalled();
+  });
+
+  it('throws FILE_TOO_LARGE over the input cap (non-emoji uses MAX_INPUT_SIZE)', async () => {
+    const platform = mockPlatform();
+    const tooBig = file(FILE_SIZE_LIMITS.MAX_INPUT_SIZE + 1);
+    await expect(processImageWithConfig(tooBig, 'avatar', platform)).rejects.toMatchObject({
+      code: 'FILE_TOO_LARGE',
+      limitBytes: FILE_SIZE_LIMITS.MAX_INPUT_SIZE,
+    });
+    expect(platform.compress).not.toHaveBeenCalled();
+  });
+
+  it('uses the smaller emoji input cap for emoji', async () => {
+    const platform = mockPlatform();
+    // Between emoji cap and general cap: rejected for emoji...
+    const between = file(FILE_SIZE_LIMITS.MAX_EMOJI_INPUT_SIZE + 1);
+    await expect(processImageWithConfig(between, 'emoji', platform)).rejects.toMatchObject({
+      code: 'FILE_TOO_LARGE',
+      limitBytes: FILE_SIZE_LIMITS.MAX_EMOJI_INPUT_SIZE,
+    });
+    // ...but accepted for a non-emoji surface.
+    await expect(processImageWithConfig(between, 'avatar', platform)).resolves.toEqual({
+      tag: 'compress',
+    });
+  });
+
+  it('wraps a compressor failure in COMPRESSION_FAILED (per surface)', async () => {
+    const platform = mockPlatform({
+      compress: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+    });
+    await expect(processImageWithConfig(file(1000), 'emoji', platform)).rejects.toMatchObject({
+      code: 'EMOJI_COMPRESSION_FAILED',
+    });
+    await expect(processImageWithConfig(file(1000), 'sticker', platform)).rejects.toMatchObject({
+      code: 'STICKER_COMPRESSION_FAILED',
+    });
+    await expect(processImageWithConfig(file(1000), 'avatar', platform)).rejects.toMatchObject({
+      code: 'COMPRESSION_FAILED',
+    });
+  });
+
+  it('passes ImageProcessingError through unchanged', async () => {
+    const platform = mockPlatform({
+      compress: vi.fn(async () => {
+        throw new ImageProcessingError('FILE_TOO_LARGE', 123);
+      }),
+    });
+    await expect(processImageWithConfig(file(1000), 'avatar', platform)).rejects.toMatchObject({
+      code: 'FILE_TOO_LARGE',
+      limitBytes: 123,
+    });
+  });
+});
+
+describe('shouldGenerateGifThumbnail', () => {
+  it('is true for large GIFs on a surface with a thumbnail config', () => {
+    const config = IMAGE_CONFIGS.messageAttachment;
+    const threshold = config.thumbnailConfig!.threshold * 1024;
+    expect(shouldGenerateGifThumbnail(file(threshold + 1, 'image/gif'), config)).toBe(true);
+    expect(shouldGenerateGifThumbnail(file(threshold - 1, 'image/gif'), config)).toBe(false);
+  });
+
+  it('is false for surfaces without a thumbnail config', () => {
+    expect(shouldGenerateGifThumbnail(file(10_000_000, 'image/gif'), IMAGE_CONFIGS.emoji)).toBe(
+      false,
+    );
+  });
+});
+
+describe('processAttachmentWithConfig', () => {
+  it('returns a single full image for small static images (no thumbnail)', async () => {
+    const platform = mockPlatform({ getDimensions: vi.fn(async () => ({ width: 100, height: 100 })) });
+    const genThumb = vi.fn(async () => ({ tag: 'thumb' }));
+    const r = await processAttachmentWithConfig(file(1000), platform, genThumb);
+    expect(r.full).toEqual({ tag: 'compress' });
+    expect(r.thumbnail).toBeUndefined();
+    expect(platform.compress).toHaveBeenCalledOnce();
+  });
+
+  it('generates a thumbnail + full for large static images (> 300px)', async () => {
+    const platform = mockPlatform({ getDimensions: vi.fn(async () => ({ width: 1000, height: 1000 })) });
+    const genThumb = vi.fn(async () => ({ tag: 'thumb' }));
+    const r = await processAttachmentWithConfig(file(1000), platform, genThumb);
+    expect(r.thumbnail).toEqual({ tag: 'compress' }); // thumbnail also goes through compress
+    expect(r.full).toEqual({ tag: 'compress' });
+    expect(platform.compress).toHaveBeenCalledTimes(2);
+  });
+
+  it('marks large GIFs and uses the injected thumbnail generator', async () => {
+    const platform = mockPlatform();
+    const genThumb = vi.fn(async () => ({ tag: 'thumb' }));
+    const big = file(FILE_SIZE_LIMITS.GIF_THUMBNAIL_THRESHOLD + 1, 'image/gif');
+    const r = await processAttachmentWithConfig(big, platform, genThumb);
+    expect(r.isLargeGif).toBe(true);
+    expect(r.thumbnail).toEqual({ tag: 'thumb' });
+    expect(r.full).toEqual({ tag: 'gif' });
+    expect(genThumb).toHaveBeenCalledOnce();
+  });
+});

--- a/src/utils/imageOrchestration.ts
+++ b/src/utils/imageOrchestration.ts
@@ -1,0 +1,193 @@
+/**
+ * Platform-agnostic image-processing orchestration.
+ *
+ * This module owns the cross-platform LOGIC — input-size validation, GIF vs
+ * static routing, thumbnail decisions — but performs none of the actual
+ * pixel-pushing. The platform injects its compressor and dimension reader via
+ * the `ImagePlatform` adapter (compressorjs on desktop, expo-image-manipulator
+ * on mobile).
+ *
+ * Like imageConfig.ts, this is PURE: no DOM, no native, no i18n imports. Errors
+ * are surfaced as typed `ImageProcessingError` codes; each platform maps codes
+ * to localized user-facing text.
+ */
+
+import {
+  FILE_SIZE_LIMITS,
+  IMAGE_CONFIGS,
+  ImageConfig,
+  ImageConfigType,
+  ImageProcessingOptions,
+} from './imageConfig';
+
+/** Stable error codes the platform maps to localized messages. */
+export type ImageErrorCode =
+  | 'FILE_TOO_LARGE'
+  | 'GIF_TOO_LARGE'
+  | 'COMPRESSION_FAILED'
+  | 'EMOJI_COMPRESSION_FAILED'
+  | 'STICKER_COMPRESSION_FAILED';
+
+export class ImageProcessingError extends Error {
+  code: ImageErrorCode;
+  /** Limit (bytes) relevant to size errors, for message formatting. */
+  limitBytes?: number;
+  constructor(code: ImageErrorCode, limitBytes?: number) {
+    super(code);
+    this.name = 'ImageProcessingError';
+    this.code = code;
+    this.limitBytes = limitBytes;
+  }
+}
+
+/**
+ * Minimal description of an input image the orchestrator needs, independent of
+ * platform file types. `size` is bytes, `type` is the MIME type.
+ */
+export interface ImageInput {
+  size: number;
+  type: string;
+}
+
+/**
+ * Platform adapter the orchestrator depends on. `R` is the platform's processed
+ * result type (e.g. desktop `ProcessedImage` wrapping a `File`).
+ */
+export interface ImagePlatform<F extends ImageInput, R> {
+  /** Re-encode/resize `file` per `opts`, returning the platform result. */
+  compress: (file: F, opts: ImageProcessingOptions) => Promise<R>;
+  /** Pass a GIF through unchanged (animation preserved), returning a result. */
+  passthroughGif: (file: F, config: ImageConfig) => Promise<R>;
+  /** Natural pixel dimensions of `file`. */
+  getDimensions: (file: F) => Promise<{ width: number; height: number }>;
+}
+
+/** Input-size guard shared by all surfaces. */
+function validateInputFileSize(file: ImageInput, config: ImageConfig): void {
+  const maxInputSize =
+    config === IMAGE_CONFIGS.emoji
+      ? FILE_SIZE_LIMITS.MAX_EMOJI_INPUT_SIZE
+      : FILE_SIZE_LIMITS.MAX_INPUT_SIZE;
+
+  if (file.size > maxInputSize) {
+    throw new ImageProcessingError('FILE_TOO_LARGE', maxInputSize);
+  }
+}
+
+function compressionFailureCode(config: ImageConfig): ImageErrorCode {
+  if (config === IMAGE_CONFIGS.emoji) return 'EMOJI_COMPRESSION_FAILED';
+  if (config === IMAGE_CONFIGS.sticker) return 'STICKER_COMPRESSION_FAILED';
+  return 'COMPRESSION_FAILED';
+}
+
+function optsFromConfig(config: ImageConfig): ImageProcessingOptions {
+  return {
+    maxWidth: config.maxWidth,
+    maxHeight: config.maxHeight,
+    quality: config.quality,
+    cropToFit: config.cropToFit,
+    maintainAspectRatio: config.maintainAspectRatio,
+    skipCompressionThreshold: config.skipCompressionThreshold,
+  };
+}
+
+/**
+ * Process a single-image surface (avatar, space icon, banner, emoji, sticker).
+ */
+export async function processImageWithConfig<F extends ImageInput, R>(
+  file: F,
+  type: ImageConfigType,
+  platform: ImagePlatform<F, R>,
+): Promise<R> {
+  const config = IMAGE_CONFIGS[type];
+
+  validateInputFileSize(file, config);
+
+  if (file.type === 'image/gif') {
+    return platform.passthroughGif(file, config);
+  }
+
+  try {
+    return await platform.compress(file, optsFromConfig(config));
+  } catch (error) {
+    if (error instanceof ImageProcessingError) throw error;
+    throw new ImageProcessingError(compressionFailureCode(config));
+  }
+}
+
+/** Result of processing a message attachment with optional thumbnail. */
+export interface AttachmentResult<R> {
+  thumbnail?: R;
+  full: R;
+  isLargeGif?: boolean;
+}
+
+/**
+ * Decide whether a GIF needs a static thumbnail (large GIFs get a poster frame).
+ */
+export function shouldGenerateGifThumbnail(file: ImageInput, config: ImageConfig): boolean {
+  return Boolean(
+    config.thumbnailConfig &&
+      config.preserveGifAnimation &&
+      file.size > config.thumbnailConfig.threshold * 1024,
+  );
+}
+
+/**
+ * Process a message attachment, generating a thumbnail when the source is large.
+ * `generateGifThumbnail` is injected because GIF poster-frame extraction is
+ * platform-specific (canvas on web, native on mobile).
+ */
+export async function processAttachmentWithConfig<F extends ImageInput, R>(
+  file: F,
+  platform: ImagePlatform<F, R>,
+  generateGifThumbnail: (file: F, config: ImageConfig) => Promise<R>,
+): Promise<AttachmentResult<R>> {
+  const config = IMAGE_CONFIGS.messageAttachment;
+
+  validateInputFileSize(file, config);
+
+  if (file.type === 'image/gif') {
+    if (shouldGenerateGifThumbnail(file, config)) {
+      const [thumbnail, full] = await Promise.all([
+        generateGifThumbnail(file, config),
+        platform.passthroughGif(file, config),
+      ]);
+      return { thumbnail, full, isLargeGif: true };
+    }
+    const full = await platform.passthroughGif(file, config);
+    return { full };
+  }
+
+  const dimensions = await platform.getDimensions(file);
+  const tc = config.thumbnailConfig;
+
+  if (tc && (dimensions.width > tc.threshold || dimensions.height > tc.threshold)) {
+    const [thumbnail, full] = await Promise.all([
+      platform.compress(file, {
+        maxWidth: tc.maxWidth,
+        maxHeight: tc.maxHeight,
+        quality: tc.quality,
+        maintainAspectRatio: true,
+        skipCompressionThreshold: config.skipCompressionThreshold,
+      }),
+      platform.compress(file, {
+        maxWidth: config.maxWidth,
+        maxHeight: config.maxHeight,
+        quality: config.quality,
+        maintainAspectRatio: true,
+        skipCompressionThreshold: config.skipCompressionThreshold,
+      }),
+    ]);
+    return { thumbnail, full };
+  }
+
+  const full = await platform.compress(file, {
+    maxWidth: config.maxWidth,
+    maxHeight: config.maxHeight,
+    quality: config.quality,
+    maintainAspectRatio: true,
+    skipCompressionThreshold: config.skipCompressionThreshold,
+  });
+  return { full };
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -28,4 +28,6 @@ export * from './blockUtils';
 export * from './inviteDomain';
 export * from './environmentDomains';
 export * from './youtubeUtils';
+export * from './imageConfig';
+export * from './imageOrchestration';
 export { default as dayjs } from './dayjs';


### PR DESCRIPTION
## What

Adds platform-agnostic image-processing modules so **desktop and mobile share one source of truth** for image limits and orchestration, while each app keeps its own compression engine (compressorjs on web, expo-image-manipulator on native).

Until now each app had its own copy of the limits, and the per-surface dimensions had drifted (e.g. avatar 123px on desktop vs 512px on mobile, emoji 36px vs 128px). This centralizes them.

## New modules (`src/utils/`)

- **`imageConfig.ts`** — pure config/types: `FILE_SIZE_LIMITS`, `ImageConfig`, `IMAGE_CONFIGS`, `ImageConfigType`, `ImageProcessingOptions`, `getImageConfig`. No DOM/native imports, so it builds cleanly for both the web and React Native bundles.
- **`imageOrchestration.ts`** — platform-agnostic logic: input-size validation, GIF-vs-static routing, thumbnail decisions. Generic over the file type; the actual compressor is injected via an `ImagePlatform` adapter. Errors surface as typed `ImageProcessingError` codes (each platform maps codes to localized text — shared has no i18n).
- **`imageOrchestration.test.ts`** — vitest coverage for the routing/validation/thumbnail branches (11 tests).

Both are exported from the utils barrel.

## Canonical dimensions (decided with the team)

avatar **256×256**, space icon **256×256**, emoji **96×96**, sticker **512** (longest axis), space banner **1600×900** (16:9, cropped at render), message attachment **1200×1200**. GIF caps and max-input sizes unchanged. Sizing rule: ~display-size × peak device pixel ratio, capped for storage, so one source is crisp on dense mobile screens and desktop retina.

## Verification

- Typecheck clean (only a pre-existing unrelated `Input.native.tsx` error remains).
- `yarn build` green — ESM, CJS, and native bundles all compile; new symbols confirmed in `dist`.
- 11 orchestration tests pass.

## Rollout

- **Desktop** consumes this immediately via its local `link:../quorum-shared` — see QuilibriumNetwork/quorum-desktop PR (image config from shared). That PR is being dev-tested before merge.
- **Mobile** will adopt after this is published and its shared version bumped (separate tracked task).