### PR TITLE
Add shared message-preprocessing pipeline + tests

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -17,6 +17,7 @@ export * from './messageLinkUtils';
 export * from './messagePreview';
 export * from './markdownFormatting';
 export * from './markdownStripping';
+export * from './messagePreprocessing';
 export * from './codeFormatting';
 export * from './formatMentionCount';
 export * from './rateLimit';

--- a/src/utils/messagePreprocessing.test.ts
+++ b/src/utils/messagePreprocessing.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Test suite for the shared message-preprocessing pipeline.
+ *
+ * Covers the full transform matrix plus the six+ desktop↔mobile divergences the
+ * promotion reconciled (see the migration task: angle-bracket autolink skip,
+ * markdown-link protection scope, `@everyone` authorization gate, header regex,
+ * legacy bare-mention shim, and the `@<roleId>`/`@roleTag` dual role match).
+ *
+ * This is the durable home for these tests — desktop's copy was inlined and
+ * untestable; mobile has no test runner. One suite covers both platforms.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  processMentions,
+  processRoleMentions,
+  processChannelMentions,
+  processURLs,
+  convertHeadersToH3,
+  fixUnclosedCodeBlocks,
+  getProtectedRegions,
+  isInProtectedRegion,
+  prepareMessageContent,
+  hasMarkdown,
+} from './messagePreprocessing';
+import type { SpaceMember, Role, Channel } from '../types';
+
+// A valid IPFS-CID-shaped address (matches createIPFSCIDRegex).
+const ADDR = 'QmV5xWMo5CYSxgAAy6emKFZZPCKwCsBZKZxXD3mCUZF2nX';
+
+const role = (over: Partial<Role> = {}): Role => ({
+  roleId: '11111111-1111-1111-1111-111111111111',
+  displayName: 'Admin',
+  roleTag: 'admin',
+  color: 'blue',
+  members: [],
+  permissions: [],
+  ...over,
+});
+
+const channel = (over: Partial<Channel> = {}): Channel => ({
+  channelId: 'chan-123',
+  spaceId: 'space-1',
+  channelName: 'general',
+  createdDate: 0,
+  modifiedDate: 0,
+  ...over,
+});
+
+const member = (over: Partial<SpaceMember> = {}): SpaceMember =>
+  ({
+    address: ADDR,
+    name: 'alice',
+    display_name: 'Alice',
+    inbox_address: 'inbox-1',
+    ...over,
+  }) as SpaceMember;
+
+// ---------------------------------------------------------------------------
+// processMentions
+// ---------------------------------------------------------------------------
+
+describe('processMentions', () => {
+  it('tokenizes canonical @<address> user mentions', () => {
+    expect(processMentions(`hi @<${ADDR}> there`)).toBe(`hi <<<MENTION_USER:${ADDR}>>> there`);
+  });
+
+  it('tokenizes @everyone only when authorized', () => {
+    expect(processMentions('hey @everyone', [], true)).toBe('hey <<<MENTION_EVERYONE>>>');
+  });
+
+  it('leaves @everyone as plain text when NOT authorized', () => {
+    expect(processMentions('hey @everyone', [], false)).toBe('hey @everyone');
+  });
+
+  it('respects word boundaries — x@everyone does not match', () => {
+    expect(processMentions('x@everyone', [], true)).toBe('x@everyone');
+  });
+
+  it('tokenizes a mention at string start and end', () => {
+    expect(processMentions(`@<${ADDR}>`)).toBe(`<<<MENTION_USER:${ADDR}>>>`);
+  });
+
+  it('does NOT tokenize inside inline code', () => {
+    expect(processMentions(`\`@<${ADDR}>\``)).toBe(`\`@<${ADDR}>\``);
+  });
+
+  it('does NOT tokenize inside a fenced code block', () => {
+    const text = '```\n@<' + ADDR + '>\n```';
+    expect(processMentions(text)).toBe(text);
+  });
+
+  it('does NOT tokenize inside a markdown link text (divergence #2)', () => {
+    const text = `[ping @<${ADDR}>](https://x.com)`;
+    expect(processMentions(text)).toBe(text);
+  });
+
+  describe('legacy bare @address shim (divergence #5)', () => {
+    it('tokenizes a bare @name when it resolves to a member', () => {
+      expect(processMentions('hi @alice', [member()])).toBe(`hi <<<MENTION_USER:${ADDR}>>>`);
+    });
+
+    it('leaves a bare @word as plain text when no members are supplied (desktop)', () => {
+      expect(processMentions('hi @alice')).toBe('hi @alice');
+    });
+
+    it('leaves a bare @word that resolves to no member as plain text', () => {
+      expect(processMentions('hi @nobody', [member()])).toBe('hi @nobody');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// processRoleMentions
+// ---------------------------------------------------------------------------
+
+describe('processRoleMentions', () => {
+  it('tokenizes a bare @roleTag against the roles array', () => {
+    expect(processRoleMentions('ping @admin now', [role()])).toBe(
+      'ping <<<MENTION_ROLE:admin:Admin>>> now',
+    );
+  });
+
+  it('tokenizes the canonical @<roleId> form (divergence #8)', () => {
+    const r = role();
+    expect(processRoleMentions(`ping @<${r.roleId}> now`, [r])).toBe(
+      'ping <<<MENTION_ROLE:admin:Admin>>> now',
+    );
+  });
+
+  it('returns text unchanged when no roles are supplied', () => {
+    expect(processRoleMentions('ping @admin', [])).toBe('ping @admin');
+  });
+
+  it('does not tokenize @roleTag that names no existing role', () => {
+    expect(processRoleMentions('ping @notarole', [role()])).toBe('ping @notarole');
+  });
+
+  it('respects word boundaries — @adminx does not match @admin', () => {
+    expect(processRoleMentions('ping @adminx', [role()])).toBe('ping @adminx');
+  });
+
+  it('does NOT tokenize inside code', () => {
+    expect(processRoleMentions('`@admin`', [role()])).toBe('`@admin`');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// processChannelMentions
+// ---------------------------------------------------------------------------
+
+describe('processChannelMentions', () => {
+  it('tokenizes #<channelId> against the channels array', () => {
+    expect(processChannelMentions('see #<chan-123> please', [channel()])).toBe(
+      'see <<<MENTION_CHANNEL:chan-123:general>>> please',
+    );
+  });
+
+  it('returns text unchanged when no channels are supplied', () => {
+    expect(processChannelMentions('see #<chan-123>', [])).toBe('see #<chan-123>');
+  });
+
+  it('does not tokenize an unknown channel id', () => {
+    expect(processChannelMentions('see #<chan-999>', [channel()])).toBe('see #<chan-999>');
+  });
+
+  it('does NOT tokenize inside code', () => {
+    expect(processChannelMentions('`#<chan-123>`', [channel()])).toBe('`#<chan-123>`');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// processURLs
+// ---------------------------------------------------------------------------
+
+describe('processURLs', () => {
+  it('wraps a bare URL as a markdown link', () => {
+    expect(processURLs('go to https://x.com now')).toBe('go to [https://x.com](https://x.com) now');
+  });
+
+  it('skips URLs inside fenced code', () => {
+    const text = '```\nhttps://x.com\n```';
+    expect(processURLs(text)).toBe(text);
+  });
+
+  it('skips URLs inside inline code', () => {
+    expect(processURLs('`https://x.com`')).toBe('`https://x.com`');
+  });
+
+  it('skips a URL already inside an existing markdown link', () => {
+    const text = '[label](https://x.com)';
+    expect(processURLs(text)).toBe(text);
+  });
+
+  it('skips a <URL> angle-bracket autolink (divergence #1)', () => {
+    const text = '<https://x.com>';
+    expect(processURLs(text)).toBe(text);
+  });
+
+  it('wraps a bare URL even when another is autolinked nearby', () => {
+    expect(processURLs('<https://a.com> and https://b.com')).toBe(
+      '<https://a.com> and [https://b.com](https://b.com)',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// convertHeadersToH3 (divergence #4)
+// ---------------------------------------------------------------------------
+
+describe('convertHeadersToH3', () => {
+  it('converts # to ###', () => {
+    expect(convertHeadersToH3('# Title')).toBe('### Title');
+  });
+
+  it('converts ## to ###', () => {
+    expect(convertHeadersToH3('## Title')).toBe('### Title');
+  });
+
+  it('leaves ### unchanged', () => {
+    expect(convertHeadersToH3('### Title')).toBe('### Title');
+  });
+
+  it('leaves #### unchanged', () => {
+    expect(convertHeadersToH3('#### Title')).toBe('#### Title');
+  });
+
+  it('converts headers on multiple lines', () => {
+    expect(convertHeadersToH3('# A\n## B\ntext')).toBe('### A\n### B\ntext');
+  });
+
+  it('does not convert a # inside a fenced code block', () => {
+    const text = '```\n# not a header\n```';
+    expect(convertHeadersToH3(text)).toBe(text);
+  });
+
+  it('does not convert a mid-line #', () => {
+    expect(convertHeadersToH3('this # is not a header')).toBe('this # is not a header');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fixUnclosedCodeBlocks
+// ---------------------------------------------------------------------------
+
+describe('fixUnclosedCodeBlocks', () => {
+  it('appends a closing fence when the count is odd', () => {
+    expect(fixUnclosedCodeBlocks('```\ncode')).toBe('```\ncode\n```');
+  });
+
+  it('leaves balanced fences untouched', () => {
+    const text = '```\ncode\n```';
+    expect(fixUnclosedCodeBlocks(text)).toBe(text);
+  });
+
+  it('leaves text with no fences untouched', () => {
+    expect(fixUnclosedCodeBlocks('plain text')).toBe('plain text');
+  });
+
+  it('does not double-add a newline when the open fence line ends with one', () => {
+    expect(fixUnclosedCodeBlocks('```\ncode\n')).toBe('```\ncode\n```');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getProtectedRegions / isInProtectedRegion
+// ---------------------------------------------------------------------------
+
+describe('getProtectedRegions', () => {
+  it('protects fenced code, inline code, and markdown links', () => {
+    const text = '`a` [b](u) ```c```';
+    const regions = getProtectedRegions(text);
+    expect(regions.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('isInProtectedRegion reports inside vs outside correctly', () => {
+    const text = 'x `code` y';
+    const regions = getProtectedRegions(text);
+    const codeIdx = text.indexOf('code');
+    expect(isInProtectedRegion(codeIdx, regions)).toBe(true);
+    expect(isInProtectedRegion(0, regions)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasMarkdown
+// ---------------------------------------------------------------------------
+
+describe('hasMarkdown', () => {
+  it('returns false for a plain chat line', () => {
+    expect(hasMarkdown('just a normal message')).toBe(false);
+  });
+
+  it('returns false for a bare @mention / #channel / URL', () => {
+    expect(hasMarkdown(`@<${ADDR}>`)).toBe(false);
+    expect(hasMarkdown('#<chan-123>')).toBe(false);
+    expect(hasMarkdown('https://x.com')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(hasMarkdown('')).toBe(false);
+  });
+
+  it.each([
+    ['**bold**', '**b**'],
+    ['__bold__', '__b__'],
+    ['italic *', 'an *i* word'],
+    ['italic _', 'an _i_ word'],
+    ['strikethrough', '~~s~~'],
+    ['inline code', 'a `c` b'],
+    ['fenced code', '```\nx\n```'],
+    ['spoiler', '||s||'],
+    ['heading', '# h'],
+    ['blockquote', '> q'],
+    ['unordered list', '- item'],
+    ['ordered list', '1. item'],
+    ['thematic break', '---'],
+  ])('returns true for %s', (_label, input) => {
+    expect(hasMarkdown(input)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareMessageContent (orchestrator — mobile path)
+// ---------------------------------------------------------------------------
+
+describe('prepareMessageContent', () => {
+  it('normalizes CRLF newlines (divergence #6)', () => {
+    expect(prepareMessageContent('a\r\nb\rc')).toBe('a\nb\nc');
+  });
+
+  it('runs the full pipeline: mention + role + channel + url + header', () => {
+    const out = prepareMessageContent(
+      `# hi @<${ADDR}> @admin #<chan-123> https://x.com`,
+      {
+        members: [],
+        roles: [role()],
+        channels: [channel()],
+        everyoneAuthorized: false,
+      },
+    );
+    expect(out).toContain('### hi');
+    expect(out).toContain(`<<<MENTION_USER:${ADDR}>>>`);
+    expect(out).toContain('<<<MENTION_ROLE:admin:Admin>>>');
+    expect(out).toContain('<<<MENTION_CHANNEL:chan-123:general>>>');
+    expect(out).toContain('[https://x.com](https://x.com)');
+  });
+
+  it('balances an unclosed fence at the end', () => {
+    expect(prepareMessageContent('```\ncode')).toBe('```\ncode\n```');
+  });
+});

--- a/src/utils/messagePreprocessing.ts
+++ b/src/utils/messagePreprocessing.ts
@@ -1,0 +1,417 @@
+/**
+ * Message content preprocessing — pure string transforms shared by the
+ * desktop (react-markdown) and mobile (hand-rolled RN) markdown renderers.
+ *
+ * Every function here is platform-agnostic (string in, string out); only the
+ * final React rendering step is platform-specific. The pipeline converts inline
+ * mentions/roles/channels into internal tokens of the form
+ * `<<<MENTION_USER:address>>>` BEFORE the markdown layer runs, so the markdown
+ * parser never mangles an `@<address>` into emphasis/code/etc. The tokens use
+ * `<<<...>>>` delimiters that don't collide with any markdown syntax.
+ *
+ * The token vocabulary is a CROSS-PLATFORM PROTOCOL: `markdownStripping.ts`
+ * (+ `.native.ts`) already strips these exact tokens from message previews, so
+ * both renderers must produce them identically. This module is the single
+ * canonical producer.
+ *
+ * Internal token formats:
+ *   <<<MENTION_EVERYONE>>>
+ *   <<<MENTION_USER:address>>>
+ *   <<<MENTION_ROLE:roleTag:displayName>>>
+ *   <<<MENTION_CHANNEL:channelId:channelName>>>
+ * Spoilers (`||text||`) are NOT tokenized here; each renderer detects them inline.
+ *
+ * Desktop-only steps (invite links, standalone YouTube, message links) are NOT
+ * part of this module — desktop keeps those inlined and calls the individual
+ * functions below in its own order. Only mobile uses the `prepareMessageContent`
+ * orchestrator.
+ *
+ * Caller note (desktop): `processMentions` here always tokenizes. Desktop has a
+ * caller-side guard that skips tokenization when no user-resolver is wired (to
+ * avoid leaking raw tokens in lookup-less contexts). That guard lives in the
+ * desktop wrapper, NOT in this pure function.
+ */
+
+import { hasWordBoundaries } from './mentions';
+import { createIPFSCIDRegex } from './validation';
+import type { SpaceMember, Role, Channel } from '../types';
+
+export interface PreprocessOptions {
+  members?: SpaceMember[];
+  roles?: Role[];
+  channels?: Channel[];
+  /**
+   * Whether this message's `@everyone` was authorized (mentions.everyone set AND
+   * sender holds mention:everyone). When false, `@everyone` stays plain text.
+   * The caller owns this decision; the pipeline only tokenizes.
+   */
+  everyoneAuthorized?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Protected-region helpers — never tokenize/auto-link inside code or existing
+// markdown links.
+// ---------------------------------------------------------------------------
+
+interface Region {
+  start: number;
+  end: number;
+}
+
+/**
+ * Find regions where mention/URL processing must be skipped: fenced code
+ * (```...```), inline code (`...`), and existing markdown links [text](url) /
+ * ![alt](url). Protecting markdown links here (not just inside processURLs)
+ * means a mention sitting inside a link's text is left alone too — the
+ * conservative, desktop-matching behavior.
+ */
+export function getProtectedRegions(text: string): Region[] {
+  const regions: Region[] = [];
+
+  // Fenced code blocks.
+  const fenceRegex = /```[\s\S]*?```/g;
+  let m: RegExpExecArray | null;
+  while ((m = fenceRegex.exec(text)) !== null) {
+    regions.push({ start: m.index, end: m.index + m[0].length });
+  }
+
+  // Inline code — skip backticks that fall inside an already-found fence.
+  const inlineRegex = /`[^`\n]+`/g;
+  while ((m = inlineRegex.exec(text)) !== null) {
+    const start = m.index;
+    const insideFence = regions.some((r) => start >= r.start && start < r.end);
+    if (!insideFence) {
+      regions.push({ start, end: start + m[0].length });
+    }
+  }
+
+  // Existing markdown links [text](url) and image links ![alt](url) — skip any
+  // that fall inside a code region already found.
+  const mdLinkRegex = /!?\[[^\]]*\]\([^)]*\)/g;
+  while ((m = mdLinkRegex.exec(text)) !== null) {
+    const start = m.index;
+    const insideCode = regions.some((r) => start >= r.start && start < r.end);
+    if (!insideCode) {
+      regions.push({ start, end: start + m[0].length });
+    }
+  }
+
+  return regions;
+}
+
+export function isInProtectedRegion(index: number, regions: Region[]): boolean {
+  return regions.some((r) => index >= r.start && index < r.end);
+}
+
+// ---------------------------------------------------------------------------
+// Mention / role / channel tokenization
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert `@everyone` and `@<address>` user mentions into internal tokens.
+ * Also tolerates the legacy bare `@address` format already in storage from
+ * older mobile clients (matched against the member map by display name / name /
+ * address). The legacy shim only activates when `members` is non-empty, so it's
+ * inert for desktop (which never produced bare-format mentions and passes none).
+ *
+ * @param everyoneAuthorized — only tokenize `@everyone` when the caller has
+ *   confirmed authorization; an unauthorized/spoofed `@everyone` stays plain
+ *   text, matching the notification trust rule.
+ */
+export function processMentions(
+  text: string,
+  members: SpaceMember[] = [],
+  everyoneAuthorized = false,
+): string {
+  let processed = text;
+
+  // @everyone → token (only when authorized).
+  if (everyoneAuthorized) {
+    const everyoneRegex = /@everyone\b/gi;
+    const everyoneMatches = Array.from(processed.matchAll(everyoneRegex));
+    const validEveryone = everyoneMatches.filter(
+      (match) =>
+        !isInProtectedRegion(match.index!, getProtectedRegions(processed)) &&
+        hasWordBoundaries(processed, match),
+    );
+    for (let i = validEveryone.length - 1; i >= 0; i--) {
+      const match = validEveryone[i];
+      processed =
+        processed.substring(0, match.index) +
+        '<<<MENTION_EVERYONE>>>' +
+        processed.substring(match.index! + match[0].length);
+    }
+  }
+
+  // Canonical user mentions: @<address>
+  const cidPattern = createIPFSCIDRegex().source;
+  const userMentionRegex = new RegExp(`@<(${cidPattern})>`, 'g');
+  const userMatches = Array.from(processed.matchAll(userMentionRegex));
+  const validUsers = userMatches.filter(
+    (match) =>
+      hasWordBoundaries(processed, match) &&
+      !isInProtectedRegion(match.index!, getProtectedRegions(processed)),
+  );
+  for (let i = validUsers.length - 1; i >= 0; i--) {
+    const match = validUsers[i];
+    const address = match[1];
+    processed =
+      processed.substring(0, match.index) +
+      `<<<MENTION_USER:${address}>>>` +
+      processed.substring(match.index! + match[0].length);
+  }
+
+  // Legacy bare @address (no brackets) — only convert when it resolves to a
+  // known member, so ordinary "@word" text isn't accidentally tokenized.
+  if (members.length > 0) {
+    const memberByKey = buildMemberKeyMap(members);
+    const bareRegex = /@([a-zA-Z0-9_.\-]+)/g;
+    const bareMatches = Array.from(processed.matchAll(bareRegex));
+    const validBare = bareMatches.filter((match) => {
+      if (!hasWordBoundaries(processed, match)) return false;
+      if (isInProtectedRegion(match.index!, getProtectedRegions(processed))) return false;
+      return Boolean(memberByKey[match[1].toLowerCase()]);
+    });
+    for (let i = validBare.length - 1; i >= 0; i--) {
+      const match = validBare[i];
+      const member = memberByKey[match[1].toLowerCase()];
+      processed =
+        processed.substring(0, match.index) +
+        `<<<MENTION_USER:${member.address}>>>` +
+        processed.substring(match.index! + match[0].length);
+    }
+  }
+
+  return processed;
+}
+
+/**
+ * Convert role mentions into tokens. Resolves directly against the `roles`
+ * array (no pre-extracted mention-id filter): identical `@roleTag` text renders
+ * consistently regardless of how it was authored. A pill is only ever produced
+ * for a role that actually exists in the array. Matches both `@<roleId>`
+ * (canonical, angle-bracketed UUID) and bare `@roleTag` (human-typed / legacy).
+ */
+export function processRoleMentions(text: string, roles: Role[] = []): string {
+  if (roles.length === 0) return text;
+
+  let processed = text;
+
+  // @<roleId> — canonical. roleId is a UUID, angle-bracket wrapped.
+  roles.forEach((role) => {
+    const escapedId = escapeRegex(role.roleId);
+    const regex = new RegExp(`@<${escapedId}>`, 'g');
+    const matches = Array.from(processed.matchAll(regex));
+    const valid = matches.filter(
+      (match) =>
+        !isInProtectedRegion(match.index!, getProtectedRegions(processed)) &&
+        hasWordBoundaries(processed, match),
+    );
+    for (let i = valid.length - 1; i >= 0; i--) {
+      const match = valid[i];
+      processed =
+        processed.substring(0, match.index) +
+        `<<<MENTION_ROLE:${role.roleTag}:${role.displayName}>>>` +
+        processed.substring(match.index! + match[0].length);
+    }
+  });
+
+  // @roleTag — legacy / human-typed. Match the exact tag, word-bounded.
+  roles.forEach((role) => {
+    const escapedTag = escapeRegex(role.roleTag);
+    const regex = new RegExp(`@${escapedTag}(?!\\w)`, 'g');
+    const matches = Array.from(processed.matchAll(regex));
+    const valid = matches.filter(
+      (match) =>
+        !isInProtectedRegion(match.index!, getProtectedRegions(processed)) &&
+        hasWordBoundaries(processed, match),
+    );
+    for (let i = valid.length - 1; i >= 0; i--) {
+      const match = valid[i];
+      processed =
+        processed.substring(0, match.index) +
+        `<<<MENTION_ROLE:${role.roleTag}:${role.displayName}>>>` +
+        processed.substring(match.index! + match[0].length);
+    }
+  });
+
+  return processed;
+}
+
+/**
+ * Convert `#<channelId>` channel mentions into tokens, resolved directly
+ * against the `channels` array (no pre-extracted mention-id filter — same
+ * rationale as processRoleMentions).
+ */
+export function processChannelMentions(text: string, channels: Channel[] = []): string {
+  if (channels.length === 0) return text;
+
+  let processed = text;
+  channels.forEach((channel) => {
+    const escapedId = escapeRegex(channel.channelId);
+    const regex = new RegExp(`#<${escapedId}>`, 'g');
+    const matches = Array.from(processed.matchAll(regex));
+    const valid = matches.filter(
+      (match) =>
+        !isInProtectedRegion(match.index!, getProtectedRegions(processed)) &&
+        hasWordBoundaries(processed, match),
+    );
+    for (let i = valid.length - 1; i >= 0; i--) {
+      const match = valid[i];
+      processed =
+        processed.substring(0, match.index) +
+        `<<<MENTION_CHANNEL:${channel.channelId}:${channel.channelName}>>>` +
+        processed.substring(match.index! + match[0].length);
+    }
+  });
+
+  return processed;
+}
+
+// ---------------------------------------------------------------------------
+// URL / header / code-fence normalization
+// ---------------------------------------------------------------------------
+
+const URL_REGEX = /https?:\/\/[^\s<>"{}|\\^`[\]]+/g;
+
+/**
+ * Convert bare URLs to `[url](url)` markdown links, skipping code regions,
+ * existing markdown links, and `<URL>` angle-bracket autolinks (which are
+ * already links and must not be wrapped again).
+ */
+export function processURLs(text: string): string {
+  const protectedRegions = getProtectedRegions(text);
+
+  const matches: Array<{ start: number; end: number; url: string }> = [];
+  URL_REGEX.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = URL_REGEX.exec(text)) !== null) {
+    if (!isInProtectedRegion(m.index, protectedRegions)) {
+      matches.push({ start: m.index, end: m.index + m[0].length, url: m[0] });
+    }
+  }
+
+  let result = text;
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const { start, end, url } = matches[i];
+    const before = result.substring(0, start);
+    const after = result.substring(end);
+    // Skip URLs already wrapped as a <URL> angle-bracket autolink.
+    if (before.endsWith('<') && after.startsWith('>')) {
+      continue;
+    }
+    result = before + `[${url}](${url})` + after;
+  }
+  return result;
+}
+
+/**
+ * Rewrite `#`/`##` headers to `###` (the renderer only supports one header
+ * level). Headers of 3+ hashes are left alone. Code blocks are protected via
+ * placeholders so a `#` inside a fence is never rewritten.
+ */
+export function convertHeadersToH3(text: string): string {
+  const codeBlocks: string[] = [];
+  const withPlaceholders = text.replace(/```[\s\S]*?```/g, (block) => {
+    codeBlocks.push(block);
+    return `__CODE_BLOCK_${codeBlocks.length - 1}__`;
+  });
+
+  // ## or # at line start (but not ###+). Single pass.
+  const converted = withPlaceholders.replace(/^(#{1,2})(?!#)(\s+)/gm, '###$2');
+
+  return converted.replace(/__CODE_BLOCK_(\d+)__/g, (_, idx) => codeBlocks[Number(idx)]);
+}
+
+/**
+ * Append a closing fence if the message has an odd number of ``` delimiters,
+ * so an unclosed code block still renders as a code block.
+ */
+export function fixUnclosedCodeBlocks(text: string): string {
+  const parts = text.split('```');
+  if (parts.length % 2 === 0) {
+    const lastPart = parts[parts.length - 1];
+    return text + (lastPart.endsWith('\n') ? '```' : '\n```');
+  }
+  return text;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator + markdown detection (mobile uses these; desktop calls the
+// individual functions above in its own interleaved order instead)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the full preprocessing pipeline. Order: newline-normalize → mentions →
+ * roles → channels → URLs → headers → fences. Returns text ready for the
+ * markdown renderer.
+ *
+ * NOTE: desktop does NOT call this — it interleaves desktop-only steps
+ * (invite links, standalone YouTube, message links) with these and must run
+ * message-link processing before URL auto-linking. Desktop calls the individual
+ * functions; only mobile uses this orchestrator.
+ */
+export function prepareMessageContent(text: string, opts: PreprocessOptions = {}): string {
+  // Normalize newlines first. Pasted text can carry `\r\n` or bare `\r`; a
+  // per-line block parser that matches `^…$` breaks on a stray `\r`. Collapse
+  // everything to `\n`. (Desktop renders via react-markdown and skips this by
+  // calling the individual functions, not this orchestrator.)
+  let processed = text.replace(/\r\n?/g, '\n');
+  processed = processMentions(processed, opts.members, opts.everyoneAuthorized);
+  processed = processRoleMentions(processed, opts.roles);
+  processed = processChannelMentions(processed, opts.channels);
+  processed = processURLs(processed);
+  processed = convertHeadersToH3(processed);
+  processed = fixUnclosedCodeBlocks(processed);
+  return processed;
+}
+
+// Block/inline markdown syntax that warrants the full markdown renderer. Bare
+// URLs, plain `@mentions`, `#channels` and `:emoji:` do NOT count — those are
+// handled by a cheaper inline path, so a normal chat line never pays the
+// markdown cost.
+const MARKDOWN_SYNTAX_REGEX = new RegExp(
+  [
+    '\\*\\*[^*]+\\*\\*', // **bold**
+    '__[^_]+__', // __bold__
+    '(?:^|[^*])\\*[^*\\s][^*]*\\*', // *italic*
+    '(?:^|[^_])_[^_\\s][^_]*_', // _italic_
+    '~~[^~]+~~', // ~~strikethrough~~
+    '`[^`]+`', // `inline code`
+    '```', // fenced code
+    '\\|\\|[^|]+\\|\\|', // ||spoiler||
+    '^#{1,6}\\s', // # heading
+    '^>\\s', // > blockquote
+    '^[-*+]\\s', // - list item
+    '^\\d+\\.\\s', // 1. ordered list
+    '^---+$', // --- thematic break
+  ].join('|'),
+  'm',
+);
+
+/**
+ * Cheap test for whether `text` contains any markdown that requires the full
+ * renderer. Messages with none can route through a lighter inline path.
+ */
+export function hasMarkdown(text: string): boolean {
+  if (!text) return false;
+  return MARKDOWN_SYNTAX_REGEX.test(text);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildMemberKeyMap(members: SpaceMember[]): Record<string, SpaceMember> {
+  const map: Record<string, SpaceMember> = {};
+  members.forEach((m) => {
+    if (m.display_name) map[m.display_name.toLowerCase()] = m;
+    if (m.name) map[m.name.toLowerCase()] = m;
+    if (m.address) map[m.address.toLowerCase()] = m;
+  });
+  return map;
+}


### PR DESCRIPTION
## What

Promotes the message-preprocessing pipeline (pure string transforms run before the markdown renderer) into a shared module so **desktop and mobile draw from one source**. Today the same algorithm is duplicated: ~320 lines inlined in desktop's `MessageMarkdownRenderer.tsx` + a 383-line mobile-local copy.

The `<<<MENTION_*>>>` token vocabulary is a **cross-platform protocol** — `markdownStripping.ts` (+ `.native.ts`) already strips these exact tokens from previews, so both renderers must produce them identically. This adds the canonical **producer** to shared.

## Contents

- **`src/utils/messagePreprocessing.ts`** (new): `processMentions`, `processRoleMentions`, `processChannelMentions`, `processURLs`, `convertHeadersToH3`, `fixUnclosedCodeBlocks`, `getProtectedRegions`/`isInProtectedRegion`, `hasMarkdown`, `prepareMessageContent`. Pure string→string; no DOM/React/RN/`unified` — needs **no `.native` split**.
- **`src/utils/messagePreprocessing.test.ts`** (new): 59 Vitest tests covering the full matrix + each reconciled divergence.
- **`src/utils/index.ts`**: barrel export.

## Divergences reconciled (desktop ↔ mobile)

- `processURLs` keeps desktop's `<URL>` angle-bracket autolink skip (mobile lacked it — a latent bug).
- `getProtectedRegions` protects existing markdown links (desktop superset), so a mention inside `[text](url)` isn't tokenized.
- `@everyone` gated on an explicit `everyoneAuthorized` flag (caller owns authorization).
- Single-pass header regex; legacy bare-`@address` shim gated on `members` (inert for desktop); `@<roleId>`/`@roleTag` dual role match.

## Verification

- ✅ `yarn test:run` — 59/59 new, 376 total pass (15 suites)
- ✅ `yarn build` clean (ESM + CJS + .d.ts carry the new exports)
- ✅ typecheck clean for the new files (the pre-existing `Input.native.tsx` error is unrelated/untouched)
- Additive only — no existing signatures changed (safe for mobile, which is pinned to a published version).

## ⚠️ Hold merge — gated on desktop integration

**Do not merge yet.** Keep this open until the **desktop consumer PR** is green against this branch, in case the desktop refactor surfaces something that needs more commits here. Version bump (`2.1.0-34` → next) to be applied at merge time.

Consumer leg (desktop): swaps `MessageMarkdownRenderer.tsx`'s inlined functions for these shared imports, preserving the desktop-only `!mapSenderToUser` guard in its wrapper (token-leak safety). Mobile consumer leg tracked separately.