### PR TITLE
feat(types): add DeleteConversationSelfMessage wire type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,7 @@ export type {
   StickerMessage,
   PinMessage,
   DeleteConversationMessage,
+  DeleteConversationSelfMessage,
   EditMessage,
   CallOfferMessage,
   CallAnswerMessage,

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -131,6 +131,16 @@ export type DeleteConversationMessage = {
   type: 'delete-conversation';
 };
 
+// Sent to your OWN other devices to wipe the whole conversation locally.
+// Distinct from delete-conversation (targets the counterparty, only resets their
+// session). conversationAddress = the counterparty to remove; E2E-encrypted to
+// your own devices, which already know it.
+export type DeleteConversationSelfMessage = {
+  senderId: string;
+  type: 'delete-conversation-self';
+  conversationAddress: string;
+};
+
 export type EditMessage = {
   senderId: string;
   type: 'edit-message';
@@ -267,6 +277,7 @@ export type MessageContent =
   | StickerMessage
   | PinMessage
   | DeleteConversationMessage
+  | DeleteConversationSelfMessage
   | EditMessage
   | CallOfferMessage
   | CallAnswerMessage


### PR DESCRIPTION
Adds a new control-message type for syncing a DM conversation delete to your OWN other devices (delete the whole conversation locally), distinct from `delete-conversation` which targets the counterparty and only resets their encryption session.

`conversationAddress` carries the counterparty to remove; it rides inside the E2E-encrypted payload sent only to your own devices, which already hold the conversation list, so it exposes nothing new.

**Additive** — new union member + export, no existing types changed. Build green (tsup + tsc). Consumed by desktop (this batch) and mobile (after a future npm publish + bump).

Note: no version bump in this PR — leave the bump to batch with the npm publish.